### PR TITLE
[Bugfix] Fix Dark Clown

### DIFF
--- a/game/cards/dm01/brain_jacker.go
+++ b/game/cards/dm01/brain_jacker.go
@@ -25,10 +25,10 @@ func BloodySquito(c *match.Card) {
 func DarkClown(c *match.Card) {
 
 	c.Name = "Dark Clown"
-	c.Power = 4000
+	c.Power = 6000
 	c.Civ = civ.Darkness
 	c.Family = family.BrainJacker
-	c.ManaCost = 2
+	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Darkness}
 
 	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.CantAttackCreatures, fx.Suicide)


### PR DESCRIPTION
## What?
Updated cost 2 --> 4 and power 4000 --> 6000 for card "Dark Clown" in DM01.

## Why?
Match the card text