### PR TITLE
[Rulefix] Fix Horrid Worm (:eyes: needed)

### DIFF
--- a/game/cards/dm02/parasite_worm.go
+++ b/game/cards/dm02/parasite_worm.go
@@ -64,19 +64,16 @@ func HorridWorm(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
 
-		ctx.ScheduleAfter(func() {
+		hand := fx.Find(ctx.Match.Opponent(card.Player), match.HAND)
 
-			hand := fx.Find(ctx.Match.Opponent(card.Player), match.HAND)
+		if len(hand) < 1 {
+			return
+		}
 
-			if len(hand) < 1 {
-				return
-			}
-
-			discardedCard, err := ctx.Match.Opponent(card.Player).MoveCard(hand[rand.Intn(len(hand))].ID, match.HAND, match.GRAVEYARD)
-			if err == nil {
-				ctx.Match.Chat("Server", fmt.Sprintf("%s was discarded from %s's hand by Horrid Worm", discardedCard.Name, discardedCard.Player.Username()))
-			}
-		})
+		discardedCard, err := ctx.Match.Opponent(card.Player).MoveCard(hand[rand.Intn(len(hand))].ID, match.HAND, match.GRAVEYARD)
+		if err == nil {
+			ctx.Match.Chat("Server", fmt.Sprintf("%s was discarded from %s's hand by Horrid Worm", discardedCard.Name, discardedCard.Player.Username()))
+		}
 
 	}))
 


### PR DESCRIPTION
## What?
I removed the ScheduleAfter call in Horrid Worm's (DM02/parasite_worm) effect function.

## Why?
According to [TGC rulings](https://duelmasters.fandom.com/wiki/Horrid_Worm/Rulings), Horrid Worm's and similar on-attack effects should trigger before the attack happens. This ruling is explicit for [Metalwing Skyterror](https://duelmasters.fandom.com/wiki/Metalwing_Skyterror).

## How?
I removed the `ctx.ScheduleAfter()` wrapping the implementation of the effect function.

## Testing?
Ran through duels to test the scenario.

__Before change:__ When player1 breaks a shield with Horrid Worm while player2 has 0 cards in their hand, player2 discards the broken shield (discard happens after attack).

__After change:__ When player1 breaks a shield with Horrid Worm while player2 has 0 cards in their hand, player2 keeps the broken shield on their hand (discard happens before attack).

## Anything else?
- :eyes: needed: Should there be a `ScheduleBefore()` function in case of flow breaks, or is this redundant? Don't feel familiar enough with the context flow to make the call myself @sindreslungaard 