### PR TITLE
[Bugfix] Correct Roaring Great Horn's power

### DIFF
--- a/game/cards/dm01/horned_beast.go
+++ b/game/cards/dm01/horned_beast.go
@@ -11,7 +11,7 @@ import (
 func RoaringGreatHorn(c *match.Card) {
 
 	c.Name = "Roaring Great-Horn"
-	c.Power = 6000
+	c.Power = 8000
 	c.Civ = civ.Nature
 	c.Family = family.HornedBeast
 	c.ManaCost = 7


### PR DESCRIPTION
## What?
Update Roaring Great Horn's (dm01/horned_beast) power from 6000 to 8000

## Why?
It now matches the card text and has 10.000 power while attacking.