### PR TITLE
[Fix/Refactor] Elf X and cost reduction

### DIFF
--- a/game/cards/dm02/tree_folk.go
+++ b/game/cards/dm02/tree_folk.go
@@ -20,24 +20,23 @@ func ElfX(c *match.Card) {
 
 	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
 
-		if !ctx.Match.IsPlayerTurn(card.Player) {
+		// Only active if ElfX is in the battlezone
+		if card.Zone != match.BATTLEZONE {
 			return
 		}
 
-		if event, ok := ctx.Event.(*match.PlayCardEvent); ok {
+		if event, ok := ctx.Event.(*match.GetCostEvent); ok {
 
-			if card.Zone == match.BATTLEZONE && event.CardID != card.ID {
-
-				toReduce, err := ctx.Match.CurrentPlayer().Player.GetCard(event.CardID, match.HAND)
-
-				if err != nil {
-					return
-				}
-
-				toReduce.AddCondition(cnd.ReducedCost, true, card.ID)
-
+			// Only reduce your other creatures
+			if event.Card.Player != card.Player || !event.Card.HasCondition(cnd.Creature) || event.Card == card {
+				return
 			}
 
+			reduction := 1
+
+			if event.Cost-reduction > 0 {
+				event.Cost -= reduction
+			}
 		}
 
 	})

--- a/game/cnd/conditions.go
+++ b/game/cnd/conditions.go
@@ -15,5 +15,4 @@ const (
 	Slayer            = "slayer"
 	Active            = "active"
 	CantBeBlocked     = "cant_be_blocked"
-	ReducedCost       = "reduced_cost"
 )

--- a/game/fx/creature.go
+++ b/game/fx/creature.go
@@ -51,14 +51,7 @@ func Creature(card *match.Card, ctx *match.Context) {
 				return
 			}
 
-			manaCost := card.ManaCost
-			for _, condition := range card.Conditions() {
-				if condition.ID == cnd.ReducedCost {
-					if manaCost > 1 {
-						manaCost--
-					}
-				}
-			}
+			manaCost := ctx.Match.GetCost(card)
 
 			ctx.Match.NewAction(
 				card.Player,

--- a/game/fx/spell.go
+++ b/game/fx/spell.go
@@ -1,7 +1,6 @@
 package fx
 
 import (
-	"duel-masters/game/cnd"
 	"duel-masters/game/match"
 	"fmt"
 )
@@ -38,14 +37,7 @@ func Spell(card *match.Card, ctx *match.Context) {
 				return
 			}
 
-			manaCost := card.ManaCost
-			for _, condition := range card.Conditions() {
-				if condition.ID == cnd.ReducedCost {
-					if manaCost > 1 {
-						manaCost--
-					}
-				}
-			}
+			manaCost := ctx.Match.GetCost(card)
 
 			ctx.Match.NewAction(
 				card.Player,

--- a/game/match/events.go
+++ b/game/match/events.go
@@ -64,3 +64,9 @@ type GetPowerEvent struct {
 	Attacking bool
 	Power     int
 }
+
+// GetCostEvent is fired whenever a card's cost is to be used
+type GetCostEvent struct {
+	Card *Card
+	Cost int
+}

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -292,6 +292,21 @@ func (m *Match) Opponent(p *Player) *Player {
 	return m.Player1.Player
 }
 
+// GetCost returns the cost of a given card after applying conditions
+func (m *Match) GetCost(card *Card) int {
+
+	manaCost := card.ManaCost
+
+	e := &GetCostEvent{
+		Card: card,
+		Cost: manaCost,
+	}
+
+	m.HandleFx(NewContext(m, e))
+
+	return e.Cost
+}
+
 // GetPower returns the power of a given card after applying conditions
 func (m *Match) GetPower(card *Card, isAttacking bool) int {
 

--- a/game/match/player.go
+++ b/game/match/player.go
@@ -1,7 +1,6 @@
 package match
 
 import (
-	"duel-masters/game/cnd"
 	"duel-masters/server"
 	"errors"
 	"fmt"
@@ -390,14 +389,7 @@ func (p *Player) CanPlayCard(card *Card, mana []*Card) bool {
 		}
 	}
 
-	manaCost := card.ManaCost
-	for _, condition := range card.Conditions() {
-		if condition.ID == cnd.ReducedCost {
-			if manaCost > 1 {
-				manaCost--
-			}
-		}
-	}
+	manaCost := p.match.GetCost(card)
 
 	if manaCost > len(untappedMana) {
 		return false


### PR DESCRIPTION
## What?
I have implemented a GetCostEvent and new GetCost() function in `match.go`. Elf X has been changed to make use of this event to modify card cost, and no longer reduces spell costs. Tweaked `creature.go`, `spell.go` and `player.go` to make use of the new GetCost function.

## Why?
These changes make chaining reduction effects easier, and makes implementations of selective effects (f.ex. only reduce cost of Dragons) more readable. The same implementation can be used to create cost increases.

## How?
I decided to use `Barkwhip, the Smasher`'s selective power increase effect (only works on your Beast Folk) as a base for my refactor of Elf X. This seemed simpler and safer than using conditions as `AddCondition()` takes two interface{} parameters.

I had to tweak `creature.go`, `spell.go` and `player.go` to reflect this change, which does an event call through the match.GetCost() function instead of a for-loop over conditions.

## Testing?
I ran through a match with Elf X with the results:

- [x] Only reduces your creatures, not the opponent's
- [x] Does not reduce cost past 1
- [x] Does not reduce the cost of itself
- [x] Does not reduce cost of spells

## Anything Else?
The only thing I am not a 100% on is the new Player.CanPlayCard() implementation calling the players match. Scanning through the other functions quickly it seemed like you tried to keep the implementation independent of the match @sindreslungaard?

From here I was thinking to implement Essence Elf :)