### PR TITLE
Added a small fix for Liquid Scope to display both hand and shields

### DIFF
--- a/game/cards/dm03/spells.go
+++ b/game/cards/dm03/spells.go
@@ -142,26 +142,18 @@ func LiquidScope(c *match.Card) {
 			}
 
 			ids := make([]string, 0)
+			cardsCount := len(hand)
+			shieldsCount := len(shields)
 
-			for _, s := range shields {
-				ids = append(ids, s.ImageID)
+			for _, card := range append(hand, shields...) {
+				ids = append(ids, card.ImageID)
 			}
+
+			message := fmt.Sprintf("Your opponent's hand is shown first(%d), followed by their shields(%d):", cardsCount, shieldsCount)
 
 			ctx.Match.ShowCards(
 				card.Player,
-				"Your opponent's shields:",
-				ids,
-			)
-
-			ids = make([]string, 0)
-
-			for _, s := range hand {
-				ids = append(ids, s.ImageID)
-			}
-
-			ctx.Match.ShowCards(
-				card.Player,
-				"Your opponent's hand:",
+				message,
 				ids,
 			)
 		}


### PR DESCRIPTION
Hey there, 

I hope you're doing well! 👋

I've identified and addressed a small bug in the web app. Previously, Liquid Scope displayed only the cards from the opponents hand, obscuring the information from the shields panel. 
I did not mess with the font-end part of the application, just consolidated the information from both panels into a single panel and added a suggestive description 😄 

I would also like to try and add some cards in the future. Looking forward to your review and feedback !