### PR TITLE
Add KingTriumphant, AquaRider, OverloadCluster (dm06)

### DIFF
--- a/game/cards/dm06/leviathan.go
+++ b/game/cards/dm06/leviathan.go
@@ -1,0 +1,20 @@
+package dm06
+
+import (
+	"duel-masters/game/civ"
+	"duel-masters/game/family"
+	"duel-masters/game/fx"
+	"duel-masters/game/match"
+)
+
+func KingTriumphant(c *match.Card) {
+
+	c.Name = "King Triumphant"
+	c.Power = 7000
+	c.Civ = civ.Water
+	c.Family = []string{family.Leviathan}
+	c.ManaCost = 8
+	c.ManaRequirement = []string{civ.Water}
+
+	c.Use(fx.Creature, fx.Doublebreaker, ReceiveBlockerWhenOpponentPlaysCreatureOrSpell)
+}

--- a/game/cards/dm06/liquid_people.go
+++ b/game/cards/dm06/liquid_people.go
@@ -19,3 +19,15 @@ func CrystalJouster(c *match.Card) {
 	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.ReturnToHand)
 
 }
+
+func AquaRider(c *match.Card) {
+
+	c.Name = "Aqua Rider"
+	c.Power = 2000
+	c.Civ = civ.Water
+	c.Family = []string{family.LiquidPeople}
+	c.ManaCost = 4
+	c.ManaRequirement = []string{civ.Water}
+
+	c.Use(fx.Creature, ReceiveBlockerWhenOpponentPlaysCreatureOrSpell)
+}

--- a/game/cards/repository.go
+++ b/game/cards/repository.go
@@ -490,4 +490,7 @@ var DM06 = map[string]match.CardConstructor{
 	"124dc6bb-a6c3-4771-91a5-9cd2c2b198e7": dm06.FactoryShellQ,
 	"08a6f16d-36bc-48a9-a704-122875759618": dm06.Torchclencher,
 	"bc8b2d5d-f595-42d2-a10c-2ee3cd336c3f": dm06.IllusoryBerry,
+	"1ec9f300-c8cb-41c2-b9a8-b46408c49098": dm06.OverloadCluster,
+	"cf8b1897-0044-4a13-9114-c1c3ba51bedd": dm06.AquaRider,
+	"38ea8acd-e8e3-4bd9-a7c9-7d74761c3712": dm06.KingTriumphant,
 }

--- a/game/match/events.go
+++ b/game/match/events.go
@@ -54,16 +54,18 @@ type MoveCard struct {
 
 // CardMoved is fired from the *Player.MoveCard method after moving a card between containers
 type CardMoved struct {
-	CardID string
-	From   string
-	To     string
-	Source string // What caused the card to move, usually the ID of a card
+	CardID        string
+	From          string
+	To            string
+	Source        string // What caused the card to move, usually the ID of a card
+	MatchPlayerID byte
 }
 
 // SpellCast is fired when a spell is cast, either from being played or from shield triggers
 type SpellCast struct {
-	CardID     string
-	FromShield bool
+	CardID        string
+	FromShield    bool
+	MatchPlayerID byte
 }
 
 // AttackPlayer is fired when the player attempts to use a creature to attack the player

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -194,12 +194,20 @@ func (m *Match) GetPower(card *Card, isAttacking bool) int {
 func (m *Match) CastSpell(card *Card, fromShield bool) {
 
 	m.HandleFx(NewContext(m, &SpellCast{
-		CardID:     card.ID,
-		FromShield: fromShield,
+		CardID:        card.ID,
+		FromShield:    fromShield,
+		MatchPlayerID: m.getPlayerMatchId(card),
 	}))
 
 	m.BroadcastState()
 
+}
+
+func (m *Match) getPlayerMatchId(card *Card) byte {
+	if card.Player == m.Player1.Player {
+		return 1
+	}
+	return 2
 }
 
 // Battle handles a battle between two creatures
@@ -535,7 +543,7 @@ func (m *Match) ActionWarning(p *Player, message string) {
 	})
 }
 
-// DefaultActionWarning sends an actionw arning with a predefined message
+// DefaultActionWarning sends an action warning with a predefined message
 func (m *Match) DefaultActionWarning(p *Player) {
 	m.PlayerRef(p).Socket.Send(server.ActionWarningMessage{
 		Header:  "action_error",

--- a/game/match/player.go
+++ b/game/match/player.go
@@ -458,10 +458,11 @@ func (p *Player) MoveCard(cardID string, from string, to string, source string) 
 	p.mutex.Unlock()
 
 	p.match.HandleFx(NewContext(p.match, &CardMoved{
-		CardID: ref.ID,
-		From:   from,
-		To:     to,
-		Source: source,
+		CardID:        ref.ID,
+		From:          from,
+		To:            to,
+		Source:        source,
+		MatchPlayerID: p.match.getPlayerMatchId(ref),
 	}))
 
 	return ref, nil


### PR DESCRIPTION
+ Add the cards KingTriumphant, AquaRider, OverloadCluster from dm06. Added them all together since they have the exact same effect. (Used this for rulings https://duelmasters.fandom.com/wiki/Aqua_Rider/Rulings)
+ Add an event that triggers after a card is played and all its effects applied. This is handled a bit different then the other events in that I'm passing the match player that played the card as well. Looks a bit ugly, so I'm up for suggestions if you think there is a better way to get which player played the card. I've seen this handled in other parts by searching different containers for the card but that seems quite cumbersome and prone to unexpected future effects.