### PR TITLE
Add living citadel vosh dm06

### DIFF
--- a/game/cards/dm06/beast_folk.go
+++ b/game/cards/dm06/beast_folk.go
@@ -17,18 +17,16 @@ func MightyBanditAceOfThieves(c *match.Card) {
 	c.Family = []string{family.BeastFolk}
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Nature}
-	c.TapAbility = true
+	c.TapAbility = MightyBanditAceOfThievesTapAbility
 
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.TapAbility)
+}
 
-		ctx.Match.Chat("Server", fmt.Sprintf("%s activated %s's tap ability", card.Player.Username(), card.Name))
-		creatures := match.Search(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Select 1 creature from your battlezone that will gain +5000 Power", 1, 1, false)
-		for _, creature := range creatures {
-
-			creature.AddCondition(cnd.PowerAmplifier, 5000, card.ID)
-			ctx.Match.Chat("Server", fmt.Sprintf("%s was given +5000 power by %s until end of turn", creature.Name, card.Name))
-
-			card.Tapped = true
-		}
-	}))
+func MightyBanditAceOfThievesTapAbility(card *match.Card, ctx *match.Context) {
+	ctx.Match.Chat("Server", fmt.Sprintf("%s activated %s's tap ability", card.Player.Username(), card.Name))
+	creatures := match.Search(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Select 1 creature from your battlezone that will gain +5000 Power", 1, 1, false)
+	for _, creature := range creatures {
+		creature.AddCondition(cnd.PowerAmplifier, 5000, card.ID)
+		ctx.Match.Chat("Server", fmt.Sprintf("%s was given +5000 power by %s until end of turn", creature.Name, card.Name))
+	}
 }

--- a/game/cards/dm06/colony_beetle.go
+++ b/game/cards/dm06/colony_beetle.go
@@ -81,3 +81,38 @@ func FactoryShellQ(c *match.Card) {
 	})
 
 }
+
+func LivingCitadelVosh(c *match.Card) {
+
+	c.Name = "Living Citadel Vosh"
+	c.Power = 5000
+	c.Civ = civ.Nature
+	c.Family = []string{family.ColonyBeetle}
+	c.ManaCost = 5
+	c.ManaRequirement = []string{civ.Nature}
+	c.TapAbility = livingCitadelVoshTapAbility
+
+	c.Use(fx.Creature, fx.Evolution, fx.TapAbility,
+		fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+
+			fx.GiveTapAbilityToAllies(
+				card,
+				ctx,
+				func(x *match.Card) bool { return x.ID != card.ID && x.Civ == civ.Nature },
+				livingCitadelVoshTapAbility,
+			)
+
+		}),
+	)
+}
+
+func livingCitadelVoshTapAbility(card *match.Card, ctx *match.Context) {
+	cards := card.Player.PeekDeck(1)
+
+	for _, toMove := range cards {
+
+		card.Player.MoveCard(toMove.ID, match.DECK, match.MANAZONE, card.ID)
+		ctx.Match.Chat("Server", fmt.Sprintf("%s put %s into the manazone from the top of their deck", card.Player.Username(), toMove.Name))
+
+	}
+}

--- a/game/cards/dm06/cyber_cluster.go
+++ b/game/cards/dm06/cyber_cluster.go
@@ -17,14 +17,12 @@ func NeonCluster(c *match.Card) {
 	c.Family = []string{family.CyberCluster}
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Water}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 		ctx.Match.Chat("Server", fmt.Sprintf("%s activated %s's tap ability to draw 2 cards", card.Player.Username(), card.Name))
 		card.Player.DrawCards(2)
-		card.Tapped = true
-	}))
+	}
 
+	c.Use(fx.Creature, fx.TapAbility)
 }
 
 func OverloadCluster(c *match.Card) {

--- a/game/cards/dm06/cyber_lord.go
+++ b/game/cards/dm06/cyber_lord.go
@@ -17,9 +17,7 @@ func Sopian(c *match.Card) {
 	c.Family = []string{family.CyberLord}
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
 		creatures := match.Search(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Select 1 creature from your battlezone that will gain \"Can't be blocked this turn\"", 1, 1, false)
 		for _, creature := range creatures {
@@ -27,7 +25,8 @@ func Sopian(c *match.Card) {
 			creature.AddCondition(cnd.CantBeBlocked, 1, card.ID)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s was given \"Cant be blocked this turn by %s\"", creature.Name, card.Name))
 
-			card.Tapped = true
 		}
-	}))
+	}
+
+	c.Use(fx.Creature, fx.TapAbility)
 }

--- a/game/cards/dm06/death_puppet.go
+++ b/game/cards/dm06/death_puppet.go
@@ -29,9 +29,7 @@ func LupaPoisonTippedDoll(c *match.Card) {
 	c.Family = []string{family.DeathPuppet}
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Darkness}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.Chat("Server", fmt.Sprintf("%s activated %s's tap ability", card.Player.Username(), card.Name))
 		creatures := match.Search(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Select 1 creature from your battlezone that will get 'slayer'", 1, 1, false)
@@ -40,7 +38,8 @@ func LupaPoisonTippedDoll(c *match.Card) {
 			creature.AddCondition(cnd.Slayer, 1, card.ID)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s was given 'slayer' by %s until end of turn", creature.Name, card.Name))
 
-			card.Tapped = true
 		}
-	}))
+	}
+
+	c.Use(fx.Creature, fx.TapAbility)
 }

--- a/game/cards/dm06/dune_gecko.go
+++ b/game/cards/dm06/dune_gecko.go
@@ -17,9 +17,7 @@ func LegionnaireLizard(c *match.Card) {
 	c.Family = []string{family.DuneGecko}
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Fire}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.SpeedAttacker, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.Chat("Server", fmt.Sprintf("%s activated %s's tap ability to give creature  \"Speed Attacker this turn\"", card.Player.Username(), card.Name))
 		creatures := match.Filter(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Select 1 creature from your battlezone that will gain \"Speed attacker\"", 1, 1, false, func(x *match.Card) bool { return x.ID != card.ID })
@@ -28,9 +26,10 @@ func LegionnaireLizard(c *match.Card) {
 			creature.RemoveCondition(cnd.SummoningSickness)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s was given \"Speed Attacker by %s\"", creature.Name, card.Name))
 
-			card.Tapped = true
 		}
-	}))
+	}
+
+	c.Use(fx.Creature, fx.SpeedAttacker, fx.TapAbility)
 }
 
 func BadlandsLizard(c *match.Card) {

--- a/game/cards/dm06/ghost.go
+++ b/game/cards/dm06/ghost.go
@@ -63,9 +63,7 @@ func GrimSoulShadowOfReversal(c *match.Card) {
 	c.Family = []string{family.Ghost}
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Darkness}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
 		fx.SelectFilter(
 			card.Player,
@@ -80,10 +78,10 @@ func GrimSoulShadowOfReversal(c *match.Card) {
 		).Map(func(x *match.Card) {
 			card.Player.MoveCard(x.ID, match.GRAVEYARD, match.HAND, card.ID)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s was moved to %s's hand from their graveyard by Grim Soul, Shadow of Reversal", x.Name, card.Player.Username()))
-			card.Tapped = true
-
 		})
-	}))
+	}
+
+	c.Use(fx.Creature, fx.TapAbility)
 }
 
 func LoneTearShadowOfSolitude(c *match.Card) {

--- a/game/cards/dm06/human.go
+++ b/game/cards/dm06/human.go
@@ -51,9 +51,7 @@ func MigasaAdeptOfChaos(c *match.Card) {
 	c.Family = []string{family.Human}
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Fire}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.Chat("Server", fmt.Sprintf("%s activated %s's tap ability", card.Player.Username(), card.Name))
 		creatures := match.Filter(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Select 1 fire creature from your battlezone that will gain double breaker", 1, 1, false, func(x *match.Card) bool { return x.Civ == civ.Fire && x.ID != card.ID })
@@ -61,11 +59,11 @@ func MigasaAdeptOfChaos(c *match.Card) {
 			if creature.Civ == civ.Fire {
 				creature.AddCondition(cnd.DoubleBreaker, true, card.ID)
 				ctx.Match.Chat("Server", fmt.Sprintf("%s was given double breaker power by %s until end of turn", creature.Name, card.Name))
-
-				card.Tapped = true
 			}
 		}
-	}))
+	}
+
+	c.Use(fx.Creature, fx.TapAbility)
 }
 
 func ChoyaTheUnheeding(c *match.Card) {

--- a/game/cards/dm06/initiate.go
+++ b/game/cards/dm06/initiate.go
@@ -85,9 +85,7 @@ func ChenTregVizierOfBlades(c *match.Card) {
 	c.Family = []string{family.Initiate}
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Light}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
 		creatures := match.Search(card.Player, ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Chen Treg, Vizier of Blades: Select 1 of your opponent's creature and tap it.", 1, 1, false)
 
@@ -95,6 +93,7 @@ func ChenTregVizierOfBlades(c *match.Card) {
 			creature.Tapped = true
 		}
 
-		card.Tapped = true
-	}))
+	}
+
+	c.Use(fx.Creature, fx.TapAbility)
 }

--- a/game/cards/dm06/mystery_totem.go
+++ b/game/cards/dm06/mystery_totem.go
@@ -18,9 +18,7 @@ func BlissTotemAvatarOfLuck(c *match.Card) {
 	c.Family = []string{family.MysteryTotem}
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
 		fx.Select(
 			card.Player,
@@ -34,11 +32,11 @@ func BlissTotemAvatarOfLuck(c *match.Card) {
 		).Map(func(c *match.Card) {
 			card.Player.MoveCard(c.ID, match.GRAVEYARD, match.MANAZONE, card.ID)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s was moved to %s's manazone by %s", c.Name, c.Player.Username(), card.Name))
-
-			card.Tapped = true
 		})
 
-	}))
+	}
+
+	c.Use(fx.Creature, fx.TapAbility)
 }
 
 func ClobberTotem(c *match.Card) {

--- a/game/cards/dm06/parasite_worm.go
+++ b/game/cards/dm06/parasite_worm.go
@@ -17,7 +17,6 @@ func GraveWormQ(c *match.Card) {
 	c.Family = []string{family.ParasiteWorm, family.Survivor}
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Darkness}
-	c.TapAbility = true
 
 	c.Use(fx.Creature, fx.Survivor, func(card *match.Card, ctx *match.Context) {
 

--- a/game/cards/dm06/rainbow_phantom.go
+++ b/game/cards/dm06/rainbow_phantom.go
@@ -17,9 +17,7 @@ func CosmogoldSpectralKnight(c *match.Card) {
 	c.Family = []string{family.RainbowPhantom}
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Light}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
@@ -33,9 +31,10 @@ func CosmogoldSpectralKnight(c *match.Card) {
 		).Map(func(spell *match.Card) {
 			card.Player.MoveCard(spell.ID, match.MANAZONE, match.HAND, card.ID)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from the mana zone to their hand using %s's tap ability", spell.Player.Username(), spell.Name, card.Name))
-			card.Tapped = true
 		})
-	}))
+	}
+
+	c.Use(fx.Creature, fx.TapAbility)
 
 }
 

--- a/game/cards/dm06/sea_hacker.go
+++ b/game/cards/dm06/sea_hacker.go
@@ -16,9 +16,7 @@ func Aeropica(c *match.Card) {
 	c.Family = []string{family.SeaHacker}
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Water}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
 		cards := make(map[string][]*match.Card)
 
@@ -37,9 +35,9 @@ func Aeropica(c *match.Card) {
 			ctx.Match.Chat("Server", fmt.Sprintf("%s was returned to %s's hand by %s", creature.Name, creature.Player.Username(), card.Name))
 		})
 
-		card.Tapped = true
+	}
 
-	}))
+	c.Use(fx.Creature, fx.TapAbility)
 }
 
 func Zepimeteus(c *match.Card) {

--- a/game/cards/dm06/snow_faerie.go
+++ b/game/cards/dm06/snow_faerie.go
@@ -17,9 +17,7 @@ func CharmiliaTheEnticer(c *match.Card) {
 	c.Family = []string{family.SnowFaerie}
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Nature}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
 		cards := match.Filter(
 			card.Player,
@@ -39,8 +37,9 @@ func CharmiliaTheEnticer(c *match.Card) {
 		}
 
 		card.Player.ShuffleDeck()
-		card.Tapped = true
-	}))
+	}
+
+	c.Use(fx.Creature, fx.TapAbility)
 }
 
 func GarabonTheGlider(c *match.Card) {

--- a/game/cards/dm06/xenoparts.go
+++ b/game/cards/dm06/xenoparts.go
@@ -28,9 +28,7 @@ func RikabusScrewdriver(c *match.Card) {
 	c.Family = []string{family.Xenoparts}
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Fire}
-	c.TapAbility = true
-
-	c.Use(fx.Creature, fx.When(fx.TapAbility, func(card *match.Card, ctx *match.Context) {
+	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
@@ -43,7 +41,8 @@ func RikabusScrewdriver(c *match.Card) {
 			func(x *match.Card) bool { return x.HasCondition(cnd.Blocker) },
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			card.Tapped = true
 		})
-	}))
+	}
+
+	c.Use(fx.Creature, fx.TapAbility)
 }

--- a/game/cards/repository.go
+++ b/game/cards/repository.go
@@ -506,4 +506,5 @@ var DM06 = map[string]match.CardConstructor{
 	"8b7fc29b-d79c-4b08-a88e-9d055d02c6e8": dm06.CoccoLupia,
 	"38617d18-b12a-4618-8a26-3effab948fcb": dm06.VessTheOracle,
 	"a8dbcc5e-a9e8-4cc6-8b87-3b53a5701371": dm06.YulukTheOracle,
+	"7732053b-6ec5-4a62-a5c1-cccff5583366": dm06.LivingCitadelVosh,
 }

--- a/game/cnd/conditions.go
+++ b/game/cnd/conditions.go
@@ -22,4 +22,5 @@ const (
 	IncreasedCost       = "increased_cost"
 	Evolution           = "evolution"
 	Survivor            = "survivor"
+	TapAbility          = "tap_ability"
 )

--- a/game/fx/common_effects.go
+++ b/game/fx/common_effects.go
@@ -1,0 +1,42 @@
+package fx
+
+import (
+	"duel-masters/game/cnd"
+	"duel-masters/game/match"
+)
+
+func GiveTapAbilityToAllies(card *match.Card, ctx *match.Context, alliesFilter func(card *match.Card) bool, tapAbility func(card *match.Card, ctx *match.Context)) {
+	// This is added for the case where the card is added to the field. There is another creature
+	// that doesn't initially have a tap abbility but should receive one. The change doesn't propagate fast
+	// enough to the FE and that creature doesn't get tap ability until another action takes places.
+	// This is an ugly workaround.
+	FindFilter(
+		card.Player,
+		match.BATTLEZONE,
+		alliesFilter,
+	).Map(func(x *match.Card) {
+		x.AddUniqueSourceCondition(cnd.TapAbility, tapAbility, card.ID)
+	})
+
+	ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
+		if card.Zone != match.BATTLEZONE {
+			Find(
+				card.Player,
+				match.BATTLEZONE,
+			).Map(func(x *match.Card) {
+				x.RemoveConditionBySource(card.ID)
+			})
+
+			exit()
+			return
+		}
+
+		FindFilter(
+			card.Player,
+			match.BATTLEZONE,
+			alliesFilter,
+		).Map(func(x *match.Card) {
+			x.AddUniqueSourceCondition(cnd.TapAbility, tapAbility, card.ID)
+		})
+	})
+}

--- a/game/fx/creature.go
+++ b/game/fx/creature.go
@@ -467,6 +467,101 @@ func Creature(card *match.Card, ctx *match.Context) {
 
 	}
 
+	if event, ok := ctx.Event.(*match.TapAbility); ok {
+
+		// Is this event for me or someone else?
+		if event.CardID != card.ID {
+			return
+		}
+
+		if card.HasCondition(cnd.SummoningSickness) {
+			ctx.Match.WarnPlayer(card.Player, fmt.Sprintf("%s can't use tap ability because it has summoning sickness", card.Name))
+			ctx.InterruptFlow()
+			return
+		}
+
+		if card.Tapped {
+			ctx.Match.WarnPlayer(card.Player, fmt.Sprintf("%s can't use tap ability because it is already tapped", card.Name))
+			ctx.InterruptFlow()
+			return
+		}
+
+		if !card.HasCondition(cnd.TapAbility) {
+			ctx.Match.WarnPlayer(card.Player, fmt.Sprintf("%s doesn't have any related tap abilities", card.Name))
+			ctx.InterruptFlow()
+			return
+		}
+
+		// Do this last in case any other cards want to interrupt the flow
+		ctx.ScheduleAfter(func() {
+
+			tapConditions := make([]*match.Condition, 0)
+			tapConditionsSourceCards := make([]*match.Card, 0)
+
+			for _, condition := range card.Conditions() {
+				if condition.ID != cnd.TapAbility {
+					continue
+				}
+				tapConditions = append(tapConditions, &condition)
+				id, _ := condition.Src.(string)
+				sourceCard, err := card.Player.GetCard(id, match.BATTLEZONE)
+				if err == nil {
+					tapConditionsSourceCards = append(tapConditionsSourceCards, sourceCard)
+				}
+			}
+			var tapEffect interface{}
+
+			if len(tapConditions) > 1 {
+
+				ctx.Match.NewAction(
+					card.Player,
+					tapConditionsSourceCards,
+					1,
+					1,
+					"Select the source of the tap effect",
+					true)
+
+				for {
+
+					action := <-card.Player.Action
+
+					if action.Cancel {
+						ctx.InterruptFlow()
+						ctx.Match.CloseAction(card.Player)
+						return
+					}
+
+					if len(action.Cards) != 1 || !match.AssertCardsIn(tapConditionsSourceCards, action.Cards[0]) {
+						ctx.Match.ActionWarning(card.Player, "Your selection of cards does not fulfill the requirements")
+						continue
+					}
+
+					for _, condition := range tapConditions {
+
+						if condition.Src == action.Cards[0] {
+							tapEffect = condition.Val
+						}
+
+					}
+
+					ctx.Match.CloseAction(card.Player)
+
+					break
+
+				}
+			} else {
+				tapEffect = tapConditions[0].Val
+			}
+
+			if f, ok := tapEffect.(func(card *match.Card, ctx *match.Context)); ok {
+				f(card, ctx)
+			}
+
+			card.Tapped = true
+		})
+
+	}
+
 	// When destroyed
 	if event, ok := ctx.Event.(*match.CreatureDestroyed); ok {
 		if event.Card != card {

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -1,9 +1,7 @@
 package fx
 
 import (
-	"duel-masters/game/cnd"
 	"duel-masters/game/match"
-	"fmt"
 )
 
 // CardCollection is a slice of cards with a mapping function
@@ -333,30 +331,6 @@ func AttackingCreature(card *match.Card, ctx *match.Context) bool {
 
 	return false
 
-}
-
-func TapAbility(card *match.Card, ctx *match.Context) bool {
-	if event, ok := ctx.Event.(*match.TapAbility); ok {
-
-		if event.CardID != card.ID {
-			return false
-		}
-
-		if card.HasCondition(cnd.SummoningSickness) {
-			ctx.Match.WarnPlayer(card.Player, fmt.Sprintf("%s can't use tap ability because it has summoning sickness", card.Name))
-			return false
-		}
-
-		if card.Tapped {
-			ctx.Match.WarnPlayer(card.Player, fmt.Sprintf("%s can't use tap ability because it is already tapped", card.Name))
-			return false
-		}
-
-		return true
-
-	}
-
-	return false
 }
 
 // Destroyed returns true if the card was destroyed

--- a/game/fx/tap_ability.go
+++ b/game/fx/tap_ability.go
@@ -9,7 +9,7 @@ import (
 func TapAbility(card *match.Card, ctx *match.Context) {
 
 	if _, ok := ctx.Event.(*match.UntapStep); ok {
-		card.AddCondition(cnd.TapAbility, card.TapAbility, card.ID)
+		card.AddUniqueSourceCondition(cnd.TapAbility, card.TapAbility, card.ID)
 	}
 
 }

--- a/game/fx/tap_ability.go
+++ b/game/fx/tap_ability.go
@@ -1,0 +1,15 @@
+package fx
+
+import (
+	"duel-masters/game/cnd"
+	"duel-masters/game/match"
+)
+
+// Survivor adds the survivor condition every turn
+func TapAbility(card *match.Card, ctx *match.Context) {
+
+	if _, ok := ctx.Event.(*match.UntapStep); ok {
+		card.AddCondition(cnd.TapAbility, card.TapAbility, card.ID)
+	}
+
+}

--- a/game/match/card.go
+++ b/game/match/card.go
@@ -36,7 +36,7 @@ type Card struct {
 	ManaCost        int
 	ManaRequirement []string
 	PowerModifier   func(m *Match, attacking bool) int
-	TapAbility      bool
+	TapAbility      func(card *Card, ctx *Context)
 
 	attachedCards []*Card
 	conditions    []Condition

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -969,7 +969,7 @@ func (m *Match) AttackPlayer(p *PlayerReference, cardID string) {
 
 }
 
-// AttackCreature is called when the player attempts to attack the opposing player
+// AttackCreature is called when the player attempts to attack an opposing creature
 func (m *Match) AttackCreature(p *PlayerReference, cardID string) {
 
 	_, err := p.Player.GetCard(cardID, BATTLEZONE)

--- a/game/match/player.go
+++ b/game/match/player.go
@@ -612,7 +612,7 @@ func denormalizeCards(cards []*Card, partial bool) []server.CardState {
 			flags |= TappedFlag
 		}
 
-		if card.TapAbility {
+		if card.HasCondition(cnd.TapAbility) {
 			flags |= TapAbilityFlag
 		}
 


### PR DESCRIPTION
This adds living citadel vosh (dm06)

To implement this change, changes to the tap ability system were required, so I rewrote it as a condition. 
The TapAbility is still in 2 parts for every card. The TapAbility attribute on every card now holds the func with the ability, and an `fx.TapAbility` is added to the `c.Use`. This also removes the need to mark every card as tapped individually after using its TapAbility. 

By implementing Vosh, some cards end up have 2 tap ability options. If that's the case, when using the tap ability they get to choose its source
<img width="1440" alt="Screenshot 2024-07-27 at 10 22 13" src="https://github.com/user-attachments/assets/e3b8796e-5d62-40fa-b43a-54b69afd49b0">
If they only have one option they are not presented with this screen like before.

A deck for testing purposes of most of the cards affected:
`{
  "_id": {
    "$oid": "66a32d1580d545e1fb155119"
  },
  "uid": "f14866d9-64bc-461c-a00a-8be14b7dc683",
  "owner": "",
  "name": "VoshTest",
  "public": false,
  "standard": true,
  "cards": "438*4,414*4,409*4,407*4,429*4,374*4,421*4,456*4,443*4,430*4"
}`