### PR TITLE
Fix AquaHulcus drawing without choice

### DIFF
--- a/game/cards/dm01/liquid_people.go
+++ b/game/cards/dm01/liquid_people.go
@@ -18,7 +18,7 @@ func AquaHulcus(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Draw1)
+	c.Use(fx.Creature, fx.When(fx.Summoned, fx.MayDraw1))
 
 }
 

--- a/game/fx/draw.go
+++ b/game/fx/draw.go
@@ -70,3 +70,16 @@ func DrawToMana(card *match.Card, ctx *match.Context) {
 	}
 
 }
+
+func MayDraw1(card *match.Card, ctx *match.Context) {
+
+	ctx.Match.NewAction(card.Player, nil, 0, 0, "Do you want to draw a card?", true)
+
+	action := <-card.Player.Action
+
+	if !action.Cancel {
+		draw(card, ctx, 1)
+	}
+	ctx.Match.CloseAction(card.Player)
+
+}

--- a/webapp/src/views/Match.vue
+++ b/webapp/src/views/Match.vue
@@ -76,7 +76,7 @@
     <!-- action (card selection) -->
     <div v-if="action" id="action" class="action noselect">
       <span v-draggable data-ref="action">{{ action.text }}</span>
-      <span v-if="action.cards"
+      <span v-if="action.cards && action.maxSelections > 0"
         ><i> Tip: click and drag to (de)select faster</i></span
       >
       <template v-if="actionObject">


### PR DESCRIPTION
Quick and dirty fix for AquaHulcus always drawing instead of giving you a choice to draw or not.

This can be implemented more properly if needed, this is just a very quick and easy to check fix.