### PR TITLE
Add unselectable cards when searching deck

### DIFF
--- a/game/cards/dm01/berserker.go
+++ b/game/cards/dm01/berserker.go
@@ -33,24 +33,28 @@ func RaylaTruthEnforcer(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		cards := fx.SelectFilterFullList(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.DECK,
+			"Select 1 spell from your deck that will be shown to your opponent and sent to your hand",
+			1,
+			1,
+			true,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+			true,
+		)
 
-			if event.CardID == card.ID && (event.To == match.BATTLEZONE || event.To == match.SPELLZONE) {
-
-				cards := match.SearchForCnd(card.Player, ctx.Match, card.Player, match.DECK, cnd.Spell, "Select 1 spell from your deck that will be shown to your opponent and sent to your hand", 1, 1, true)
-
-				for _, c := range cards {
-					card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
-					ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
-				}
-
-				card.Player.ShuffleDeck()
-
-			}
+		for _, c := range cards {
+			card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
+			ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
 		}
 
-	})
+		card.Player.ShuffleDeck()
+
+	}))
 
 }

--- a/game/cards/dm01/berserker.go
+++ b/game/cards/dm01/berserker.go
@@ -35,7 +35,7 @@ func RaylaTruthEnforcer(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		cards := fx.SelectFilterFullList(
+		cards := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm01/spells.go
+++ b/game/cards/dm01/spells.go
@@ -193,26 +193,21 @@ func CrystalMemory(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Spell, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmICasted(card, ctx) {
+		selectedCards := fx.Select(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 card from your deck that will be sent to your hand", 1, 1, true)
 
-			selectedCards := match.Search(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 card from your deck that will be sent to your hand", 1, 1, false)
+		for _, selectedCard := range selectedCards {
 
-			for _, selectedCard := range selectedCards {
-
-				card.Player.MoveCard(selectedCard.ID, match.DECK, match.HAND, card.ID)
-
-			}
-
-			card.Player.ShuffleDeck()
-
-			ctx.Match.Chat("Server", card.Player.Username()+" retrieved a card from their deck")
+			card.Player.MoveCard(selectedCard.ID, match.DECK, match.HAND, card.ID)
 
 		}
 
-	})
+		card.Player.ShuffleDeck()
 
+		ctx.Match.Chat("Server", card.Player.Username()+" retrieved a card from their deck")
+
+	}))
 }
 
 // DarkReversal ...
@@ -276,24 +271,20 @@ func DimensionGate(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Spell, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmICasted(card, ctx) {
+		creatures := fx.SelectFilterFullList(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.HasCondition(cnd.Creature) }, true)
 
-			creatures := match.Filter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, false, func(x *match.Card) bool { return x.HasCondition(cnd.Creature) })
+		for _, creature := range creatures {
 
-			for _, creature := range creatures {
-
-				card.Player.MoveCard(creature.ID, match.DECK, match.HAND, card.ID)
-				ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from the deck to their hand", card.Player.Username(), creature.Name))
-
-			}
-
-			card.Player.ShuffleDeck()
+			card.Player.MoveCard(creature.ID, match.DECK, match.HAND, card.ID)
+			ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from the deck to their hand", card.Player.Username(), creature.Name))
 
 		}
 
-	})
+		card.Player.ShuffleDeck()
+
+	}))
 
 }
 

--- a/game/cards/dm01/spells.go
+++ b/game/cards/dm01/spells.go
@@ -273,7 +273,7 @@ func DimensionGate(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		creatures := fx.SelectFilterFullList(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.HasCondition(cnd.Creature) }, true)
+		creatures := fx.SelectFilter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.HasCondition(cnd.Creature) }, true)
 
 		for _, creature := range creatures {
 

--- a/game/cards/dm02/armored_wyvern.go
+++ b/game/cards/dm02/armored_wyvern.go
@@ -20,7 +20,7 @@ func MetalwingSkyterror(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),

--- a/game/cards/dm02/berserker.go
+++ b/game/cards/dm02/berserker.go
@@ -23,7 +23,7 @@ func LagunaLightningEnforcer(c *match.Card) {
 
 		ctx.ScheduleAfter(func() {
 
-			fx.SelectFilter(card.Player,
+			fx.SelectFilterFullList(card.Player,
 				ctx.Match,
 				card.Player,
 				match.DECK,
@@ -32,6 +32,7 @@ func LagunaLightningEnforcer(c *match.Card) {
 				1,
 				true,
 				func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+				true,
 			).Map(func(x *match.Card) {
 				x.Player.MoveCard(x.ID, match.DECK, match.HAND, card.ID)
 				ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from their deck to their hand", x.Player.Username(), x.Name))

--- a/game/cards/dm02/berserker.go
+++ b/game/cards/dm02/berserker.go
@@ -23,7 +23,7 @@ func LagunaLightningEnforcer(c *match.Card) {
 
 		ctx.ScheduleAfter(func() {
 
-			fx.SelectFilterFullList(card.Player,
+			fx.SelectFilter(card.Player,
 				ctx.Match,
 				card.Player,
 				match.DECK,

--- a/game/cards/dm02/brain_jacker.go
+++ b/game/cards/dm02/brain_jacker.go
@@ -23,7 +23,7 @@ func AmberPiercer(c *match.Card) {
 
 		ctx.ScheduleAfter(func() {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm02/cyber_lord.go
+++ b/game/cards/dm02/cyber_lord.go
@@ -80,7 +80,7 @@ func Corile(c *match.Card) {
 
 			ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action...")
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				ctx.Match.Opponent(card.Player),
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm02/cyber_virus.go
+++ b/game/cards/dm02/cyber_virus.go
@@ -22,7 +22,7 @@ func StainedGlass(c *match.Card) {
 
 		ctx.ScheduleAfter(func() {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm02/guardian.go
+++ b/game/cards/dm02/guardian.go
@@ -35,7 +35,7 @@ func PhalEegaDawnGuardian(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm02/horned_beast.go
+++ b/game/cards/dm02/horned_beast.go
@@ -19,22 +19,29 @@ func RumblingTerahorn(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmISummoned(card, ctx) {
+		cards := fx.SelectFilterFullList(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.DECK,
+			"Select 1 creature from your deck that will be shown to your opponent and sent to your hand",
+			1,
+			1,
+			true,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Creature) },
+			true,
+		)
 
-			cards := match.SearchForCnd(card.Player, ctx.Match, card.Player, match.DECK, cnd.Creature, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, true)
-
-			for _, c := range cards {
-				card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
-				ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
-			}
-
-			card.Player.ShuffleDeck()
-
+		for _, c := range cards {
+			card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
+			ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
 		}
 
-	})
+		card.Player.ShuffleDeck()
+
+	}))
 
 }
 

--- a/game/cards/dm02/horned_beast.go
+++ b/game/cards/dm02/horned_beast.go
@@ -21,7 +21,7 @@ func RumblingTerahorn(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		cards := fx.SelectFilterFullList(
+		cards := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm02/parasite_worm.go
+++ b/game/cards/dm02/parasite_worm.go
@@ -76,7 +76,7 @@ func PoisonWorm(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm02/spells.go
+++ b/game/cards/dm02/spells.go
@@ -64,24 +64,31 @@ func LogicCube(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Spell, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmICasted(card, ctx) {
+		creatures := fx.SelectFilterFullList(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.DECK,
+			"Select 1 spell from your deck that will be shown to your opponent and sent to your hand",
+			1,
+			1,
+			true,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+			true,
+		)
 
-			creatures := match.Filter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 spell from your deck that will be shown to your opponent and sent to your hand", 1, 1, false, func(x *match.Card) bool { return x.HasCondition(cnd.Spell) })
+		for _, creature := range creatures {
 
-			for _, creature := range creatures {
-
-				card.Player.MoveCard(creature.ID, match.DECK, match.HAND, card.ID)
-				ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from the deck to their hand", card.Player.Username(), creature.Name))
-
-			}
-
-			card.Player.ShuffleDeck()
+			card.Player.MoveCard(creature.ID, match.DECK, match.HAND, card.ID)
+			ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from the deck to their hand", card.Player.Username(), creature.Name))
 
 		}
 
-	})
+		card.Player.ShuffleDeck()
+
+	}))
 
 }
 

--- a/game/cards/dm02/spells.go
+++ b/game/cards/dm02/spells.go
@@ -66,7 +66,7 @@ func LogicCube(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		creatures := fx.SelectFilterFullList(
+		creatures := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -125,7 +125,7 @@ func CriticalBlade(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),

--- a/game/cards/dm03/balloon_mushroom.go
+++ b/game/cards/dm03/balloon_mushroom.go
@@ -19,7 +19,7 @@ func Psyshroom(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm03/brain_jacker.go
+++ b/game/cards/dm03/brain_jacker.go
@@ -23,7 +23,7 @@ func BonePiercer(c *match.Card) {
 
 		ctx.Match.Wait(ctx.Match.Opponent(c.Player), "Waiting for your opponent to make an action")
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm03/colony_beetle.go
+++ b/game/cards/dm03/colony_beetle.go
@@ -22,7 +22,7 @@ func PouchShell(c *match.Card) {
 
 		if match.AmISummoned(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm03/ghost.go
+++ b/game/cards/dm03/ghost.go
@@ -29,7 +29,7 @@ func JackViperShadowofDoom(c *match.Card) {
 			event.Card.Player == card.Player &&
 			event.Card.Civ == civ.Darkness {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm03/giant_insect.go
+++ b/game/cards/dm03/giant_insect.go
@@ -29,7 +29,7 @@ func Gigamantis(c *match.Card) {
 			event.Card.Player == card.Player &&
 			event.Card.Civ == civ.Nature {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm03/leviathan.go
+++ b/game/cards/dm03/leviathan.go
@@ -97,7 +97,7 @@ func KingPonitas(c *match.Card) {
 	c.Use(fx.Creature, fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
 
 		ctx.ScheduleAfter(func() {
-			waterCards := match.Filter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 wated card from your deck that will be shown to your opponent and sent to your hand", 1, 1, false, func(x *match.Card) bool { return x.Civ == civ.Water })
+			waterCards := fx.SelectFilterFullList(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 water card from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.Civ == civ.Water }, true)
 
 			for _, waterCard := range waterCards {
 

--- a/game/cards/dm03/leviathan.go
+++ b/game/cards/dm03/leviathan.go
@@ -97,7 +97,7 @@ func KingPonitas(c *match.Card) {
 	c.Use(fx.Creature, fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
 
 		ctx.ScheduleAfter(func() {
-			waterCards := fx.SelectFilterFullList(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 water card from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.Civ == civ.Water }, true)
+			waterCards := fx.SelectFilter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 water card from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.Civ == civ.Water }, true)
 
 			for _, waterCard := range waterCards {
 

--- a/game/cards/dm03/spells.go
+++ b/game/cards/dm03/spells.go
@@ -70,7 +70,7 @@ func SundropArmor(c *match.Card) {
 
 		if match.AmICasted(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,
@@ -396,7 +396,7 @@ func VolcanicArrows(c *match.Card) {
 				ctx.Match.MoveCard(x, match.GRAVEYARD, card)
 			})
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),
@@ -487,7 +487,7 @@ func RoarOfTheEarth(c *match.Card) {
 
 		if match.AmICasted(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm04/giant_insect.go
+++ b/game/cards/dm04/giant_insect.go
@@ -30,7 +30,7 @@ func ThreeEyedDragonfly(c *match.Card) {
 			// reset this before each attack attempt
 			selectedCard = ""
 
-			cards := fx.SelectFilter(
+			cards := fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm04/horned_beast.go
+++ b/game/cards/dm04/horned_beast.go
@@ -21,7 +21,7 @@ func NiofaHornedProtector(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		cards := match.Filter(
+		cards := fx.SelectFilterFullList(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -31,6 +31,7 @@ func NiofaHornedProtector(c *match.Card) {
 			1,
 			false,
 			func(x *match.Card) bool { return x.HasCondition(cnd.Creature) && x.Civ == civ.Nature },
+			true,
 		)
 
 		for _, c := range cards {

--- a/game/cards/dm04/horned_beast.go
+++ b/game/cards/dm04/horned_beast.go
@@ -21,7 +21,7 @@ func NiofaHornedProtector(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		cards := fx.SelectFilterFullList(
+		cards := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm04/living_dead.go
+++ b/game/cards/dm04/living_dead.go
@@ -20,7 +20,7 @@ func SkeletonThiefTheRevealer(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm04/rock_beast.go
+++ b/game/cards/dm04/rock_beast.go
@@ -22,7 +22,7 @@ func DoboulgyserGiantRockBeast(c *match.Card) {
 
 		if match.AmISummoned(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm04/spells.go
+++ b/game/cards/dm04/spells.go
@@ -84,7 +84,7 @@ func MegaDetonator(c *match.Card) {
 
 		n := 0
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm05/angel_command.go
+++ b/game/cards/dm05/angel_command.go
@@ -35,7 +35,7 @@ func SyforceAuroraElemental(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Blocker, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm05/fire_bird.go
+++ b/game/cards/dm05/fire_bird.go
@@ -29,7 +29,7 @@ func KipChippotto(c *match.Card) {
 			event.Card.Player == card.Player &&
 			event.Card.HasFamily(family.ArmoredDragon) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm05/giant_insect.go
+++ b/game/cards/dm05/giant_insect.go
@@ -52,7 +52,7 @@ func ScissorScarab(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterFullList(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -61,7 +61,9 @@ func ScissorScarab(c *match.Card) {
 			1,
 			1,
 			true,
-			func(c *match.Card) bool { return c.HasFamily(family.GiantInsect) }).Map(func(c *match.Card) {
+			func(c *match.Card) bool { return c.HasFamily(family.GiantInsect) },
+			true,
+		).Map(func(c *match.Card) {
 			card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
 		})

--- a/game/cards/dm05/giant_insect.go
+++ b/game/cards/dm05/giant_insect.go
@@ -21,7 +21,7 @@ func BloodwingMantis(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -52,7 +52,7 @@ func ScissorScarab(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilterFullList(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -86,7 +86,7 @@ func AmbushScorpion(c *match.Card) {
 
 	c.Use(fx.Creature, fx.PowerAttacker3000, fx.When(fx.Destroyed, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -124,7 +124,7 @@ func ObsidianScarab(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Doublebreaker, fx.PowerAttacker3000, fx.When(fx.Destroyed, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm05/spells.go
+++ b/game/cards/dm05/spells.go
@@ -210,7 +210,7 @@ func BrutalCharge(c *match.Card) {
 
 			if cardPlayed {
 
-				fx.SelectFilter(
+				fx.SelectFilterFullList(
 					card.Player,
 					ctx.Match,
 					card.Player,
@@ -220,6 +220,7 @@ func BrutalCharge(c *match.Card) {
 					shieldsBroken,
 					true,
 					func(c *match.Card) bool { return c.HasCondition(cnd.Creature) },
+					true,
 				).Map(func(c *match.Card) {
 					c.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
 					ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand by %s", c.Name, c.Player.Username(), card.Name))

--- a/game/cards/dm05/spells.go
+++ b/game/cards/dm05/spells.go
@@ -20,7 +20,7 @@ func EnchantedSoil(c *match.Card) {
 
 		if match.AmICasted(card, ctx) {
 
-			fx.SelectFilter(card.Player, ctx.Match, card.Player, match.GRAVEYARD, "Enchanted Soil: Select 2 creatures from your graveyard and put it in your manazone", 0, 2, true, func(x *match.Card) bool {
+			fx.SelectFilterSelectablesOnly(card.Player, ctx.Match, card.Player, match.GRAVEYARD, "Enchanted Soil: Select 2 creatures from your graveyard and put it in your manazone", 0, 2, true, func(x *match.Card) bool {
 				return x.HasCondition(cnd.Creature)
 			}).Map(func(c *match.Card) {
 				card.Player.MoveCard(c.ID, match.GRAVEYARD, match.MANAZONE, card.ID)
@@ -210,7 +210,7 @@ func BrutalCharge(c *match.Card) {
 
 			if cardPlayed {
 
-				fx.SelectFilterFullList(
+				fx.SelectFilter(
 					card.Player,
 					ctx.Match,
 					card.Player,

--- a/game/cards/dm06/colony_beetle.go
+++ b/game/cards/dm06/colony_beetle.go
@@ -60,7 +60,7 @@ func FactoryShellQ(c *match.Card) {
 				return
 			}
 
-			fx.SelectFilter(
+			fx.SelectFilterFullList(
 				card.Player,
 				ctx.Match,
 				card.Player,
@@ -70,6 +70,7 @@ func FactoryShellQ(c *match.Card) {
 				1,
 				true,
 				func(x *match.Card) bool { return x.HasCondition(cnd.Survivor) },
+				true,
 			).Map(func(x *match.Card) {
 				card.Player.MoveCard(x.ID, match.DECK, match.HAND, card.ID)
 				ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", x.Name, card.Player.Username()))

--- a/game/cards/dm06/colony_beetle.go
+++ b/game/cards/dm06/colony_beetle.go
@@ -60,7 +60,7 @@ func FactoryShellQ(c *match.Card) {
 				return
 			}
 
-			fx.SelectFilterFullList(
+			fx.SelectFilter(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm06/dragonoid.go
+++ b/game/cards/dm06/dragonoid.go
@@ -78,7 +78,7 @@ func LavaWalkerExecuto(c *match.Card) {
 }
 
 func lavaWalkerExecutoTapAbility(card *match.Card, ctx *match.Context) {
-	creatures := fx.SelectFilter(
+	creatures := fx.SelectFilterSelectablesOnly(
 		card.Player,
 		ctx.Match,
 		card.Player,

--- a/game/cards/dm06/ghost.go
+++ b/game/cards/dm06/ghost.go
@@ -65,7 +65,7 @@ func GrimSoulShadowOfReversal(c *match.Card) {
 	c.ManaRequirement = []string{civ.Darkness}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -36,7 +36,7 @@ func ForbosSanctumGuardianQ(c *match.Card) {
 				return
 			}
 
-			fx.SelectFilter(
+			fx.SelectFilterFullList(
 				card.Player,
 				ctx.Match,
 				card.Player,
@@ -46,6 +46,7 @@ func ForbosSanctumGuardianQ(c *match.Card) {
 				1,
 				true,
 				func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+				true,
 			).Map(func(x *match.Card) {
 				card.Player.MoveCard(x.ID, match.DECK, match.HAND, card.ID)
 				ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", x.Name, card.Player.Username()))

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -36,7 +36,7 @@ func ForbosSanctumGuardianQ(c *match.Card) {
 				return
 			}
 
-			fx.SelectFilterFullList(
+			fx.SelectFilter(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm06/human.go
+++ b/game/cards/dm06/human.go
@@ -22,7 +22,7 @@ func ArmoredDecimatorValkaizer(c *match.Card) {
 
 		if match.AmISummoned(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm06/parasite_worm.go
+++ b/game/cards/dm06/parasite_worm.go
@@ -33,7 +33,7 @@ func GraveWormQ(c *match.Card) {
 			}
 
 			if creature.HasFamily(family.Survivor) && event.To == match.BATTLEZONE {
-				fx.SelectFilter(
+				fx.SelectFilterSelectablesOnly(
 					card.Player,
 					ctx.Match,
 					card.Player,

--- a/game/cards/dm06/rainbow_phantom.go
+++ b/game/cards/dm06/rainbow_phantom.go
@@ -18,7 +18,7 @@ func CosmogoldSpectralKnight(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Light}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm06/snow_faerie.go
+++ b/game/cards/dm06/snow_faerie.go
@@ -19,7 +19,7 @@ func CharmiliaTheEnticer(c *match.Card) {
 	c.ManaRequirement = []string{civ.Nature}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
-		cards := match.Filter(
+		cards := fx.SelectFilterFullList(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -29,6 +29,7 @@ func CharmiliaTheEnticer(c *match.Card) {
 			1,
 			false,
 			func(x *match.Card) bool { return x.HasCondition(cnd.Creature) },
+			true,
 		)
 
 		for _, c := range cards {

--- a/game/cards/dm06/snow_faerie.go
+++ b/game/cards/dm06/snow_faerie.go
@@ -19,7 +19,7 @@ func CharmiliaTheEnticer(c *match.Card) {
 	c.ManaRequirement = []string{civ.Nature}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
-		cards := fx.SelectFilterFullList(
+		cards := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm06/spells.go
+++ b/game/cards/dm06/spells.go
@@ -62,7 +62,7 @@ func InvincibleTechnology(c *match.Card) {
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		selectedCards := match.Search(card.Player, ctx.Match, card.Player, match.DECK, "Select any number of cards from your deck that will be sent to your hand", 1, 100, false)
+		selectedCards := fx.Select(card.Player, ctx.Match, card.Player, match.DECK, "Select any number of cards from your deck that will be sent to your hand", 0, 100, false)
 
 		for _, selectedCard := range selectedCards {
 
@@ -316,7 +316,7 @@ func MysticTreasureChest(c *match.Card) {
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterFullList(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -325,7 +325,9 @@ func MysticTreasureChest(c *match.Card) {
 			1,
 			1,
 			true,
-			func(c *match.Card) bool { return c.Civ != civ.Nature }).Map(func(x *match.Card) {
+			func(c *match.Card) bool { return c.Civ != civ.Nature },
+			true,
+		).Map(func(x *match.Card) {
 			x.Player.MoveCard(x.ID, match.DECK, match.MANAZONE, card.ID)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s put %s in their manazone from their deck", x.Player.Username(), x.Name))
 		})

--- a/game/cards/dm06/spells.go
+++ b/game/cards/dm06/spells.go
@@ -17,7 +17,7 @@ func ProtectiveForce(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -316,7 +316,7 @@ func MysticTreasureChest(c *match.Card) {
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilterFullList(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -348,7 +348,7 @@ func PangaeasWill(c *match.Card) {
 
 		if match.AmICasted(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),
@@ -513,7 +513,7 @@ func CometMissile(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		creatures := fx.SelectFilter(
+		creatures := fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),

--- a/game/cards/dm06/xenoparts.go
+++ b/game/cards/dm06/xenoparts.go
@@ -29,7 +29,7 @@ func RikabusScrewdriver(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Fire}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -67,7 +67,15 @@ func Select(p *match.Player, m *match.Match, containerOwner *match.Player, conta
 }
 
 // SelectFilter prompts the user to select n cards from the specified container that matches the given filter
+//
+// Deprecated: New cards should use `fx.SelectFilterFullList`
 func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool) CardCollection {
+	return SelectFilterFullList(p, m, containerOwner, containerName, text, min, max, cancellable, filter, false)
+}
+
+// SelectFilter prompts the user to select n cards from the specified container that matches the given filter.
+// It also allows to show all the other cards from the container that are unselectable
+func SelectFilterFullList(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool, showUnselectables bool) CardCollection {
 
 	result := make([]*match.Card, 0)
 
@@ -78,10 +86,13 @@ func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player,
 	}
 
 	filtered := make([]*match.Card, 0)
+	unselectables := make([]*match.Card, 0)
 
 	for _, mCard := range cards {
 		if filter(mCard) {
 			filtered = append(filtered, mCard)
+		} else if showUnselectables {
+			unselectables = append(unselectables, mCard)
 		}
 	}
 
@@ -89,7 +100,7 @@ func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player,
 		return result
 	}
 
-	m.NewAction(p, filtered, min, max, text, cancellable)
+	m.NewActionFullList(p, filtered, min, max, text, cancellable, unselectables)
 
 	defer m.CloseAction(p)
 

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -63,19 +63,19 @@ func When(test func(*match.Card, *match.Context) bool, h func(*match.Card, *matc
 
 // Select prompts the user to select n cards from the specified container
 func Select(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool) CardCollection {
-	return SelectFilter(p, m, containerOwner, containerName, text, min, max, cancellable, func(x *match.Card) bool { return true })
+	return SelectFilterSelectablesOnly(p, m, containerOwner, containerName, text, min, max, cancellable, func(x *match.Card) bool { return true })
 }
 
-// SelectFilter prompts the user to select n cards from the specified container that matches the given filter
+// SelectFilterSelectablesOnly prompts the user to select n cards from the specified container that matches the given filter
 //
-// Deprecated: New cards should use `fx.SelectFilterFullList`
-func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool) CardCollection {
-	return SelectFilterFullList(p, m, containerOwner, containerName, text, min, max, cancellable, filter, false)
+// Deprecated: New cards should use `fx.SelectFilter`
+func SelectFilterSelectablesOnly(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool) CardCollection {
+	return SelectFilter(p, m, containerOwner, containerName, text, min, max, cancellable, filter, false)
 }
 
 // SelectFilter prompts the user to select n cards from the specified container that matches the given filter.
 // It also allows to show all the other cards from the container that are unselectable
-func SelectFilterFullList(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool, showUnselectables bool) CardCollection {
+func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool, showUnselectables bool) CardCollection {
 
 	result := make([]*match.Card, 0)
 

--- a/game/match/helpers.go
+++ b/game/match/helpers.go
@@ -74,7 +74,7 @@ func Search(p *Player, m *Match, containerOwner *Player, containerName string, t
 
 // SearchForCnd prompts the user to select n cards from the specified container that matches the given condition
 //
-// Deprecated: New cards should use `fx.SelectFilter`
+// Deprecated: New cards should use `fx.SelectFilterSelectablesOnly`
 func SearchForCnd(p *Player, m *Match, containerOwner *Player, containerName string, condition string, text string, min int, max int, cancellable bool) []*Card {
 
 	result := make([]*Card, 0)
@@ -135,7 +135,7 @@ func SearchForCnd(p *Player, m *Match, containerOwner *Player, containerName str
 
 // SearchForFamily prompts the user to select n cards from the specified container that matches the given family
 //
-// Deprecated: New cards should use `fx.SelectFilter`
+// Deprecated: New cards should use `fx.SelectFilterSelectablesOnly`
 func SearchForFamily(p *Player, m *Match, containerOwner *Player, containerName string, family string, text string, min int, max int, cancellable bool) []*Card {
 
 	result := make([]*Card, 0)
@@ -196,7 +196,7 @@ func SearchForFamily(p *Player, m *Match, containerOwner *Player, containerName 
 
 // Filter prompts the user to select n cards from the specified container that matches the given filter
 //
-// Deprecated: New cards should use `fx.SelectFilter`
+// Deprecated: New cards should use `fx.SelectFilterSelectablesOnly`
 func Filter(p *Player, m *Match, containerOwner *Player, containerName string, text string, min int, max int, cancellable bool, filter func(*Card) bool) []*Card {
 
 	result := make([]*Card, 0)

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -622,14 +622,19 @@ func (m *Match) HandleFx(ctx *Context) {
 
 // NewAction prompts the user to make a selection of the specified []Cards
 func (m *Match) NewAction(player *Player, cards []*Card, minSelections int, maxSelections int, text string, cancellable bool) {
+	m.NewActionFullList(player, cards, minSelections, maxSelections, text, cancellable, nil)
+}
+
+func (m *Match) NewActionFullList(player *Player, cards []*Card, minSelections int, maxSelections int, text string, cancellable bool, unselectableCards []*Card) {
 
 	msg := &server.ActionMessage{
-		Header:        "action",
-		Cards:         denormalizeCards(cards, false),
-		Text:          text,
-		MinSelections: minSelections,
-		MaxSelections: maxSelections,
-		Cancellable:   cancellable,
+		Header:            "action",
+		Cards:             denormalizeCards(cards, false),
+		Text:              text,
+		MinSelections:     minSelections,
+		MaxSelections:     maxSelections,
+		Cancellable:       cancellable,
+		UnselectableCards: denormalizeCards(unselectableCards, false),
 	}
 
 	player.ActionState = PlayerActionState{

--- a/server/messages.go
+++ b/server/messages.go
@@ -67,12 +67,13 @@ type WarningMessage struct {
 
 // ActionMessage is used to prompt the user to make a selection of the specified cards
 type ActionMessage struct {
-	Header        string      `json:"header"`
-	Cards         []CardState `json:"cards"`
-	Text          string      `json:"text"`
-	MinSelections int         `json:"minSelections"`
-	MaxSelections int         `json:"maxSelections"`
-	Cancellable   bool        `json:"cancellable"`
+	Header            string      `json:"header"`
+	Cards             []CardState `json:"cards"`
+	Text              string      `json:"text"`
+	MinSelections     int         `json:"minSelections"`
+	MaxSelections     int         `json:"maxSelections"`
+	Cancellable       bool        `json:"cancellable"`
+	UnselectableCards []CardState `json:"unselectableCards"`
 }
 
 // MultipartActionMessage is used to prompt the user to make a selection of the specified cards

--- a/webapp/src/views/Match.vue
+++ b/webapp/src/views/Match.vue
@@ -109,6 +109,20 @@
             />
           </div>
         </div>
+        <div v-for="(card, index) in action.unselectableCards" :key="index" class="card">
+          <div class="action-shield-number">
+            <span>{{
+              state.me.shieldMap[card.virtualId] ||
+              state.opponent.shieldMap[card.virtualId]
+            }}</span>
+            <img
+              @contextmenu.prevent="showLarge(card)"
+              @dragstart.prevent=""
+              class="no-drag unselectable-card"
+              :src="`https://scans.shobu.io/${card.uid}.jpg`"
+            />
+          </div>
+        </div>
       </div>
       <div v-if="actionObject && action.cards" class="action-cards">
         <div
@@ -1232,7 +1246,8 @@ export default {
               text: data.text,
               minSelection: data.minSelection,
               maxSelections: data.maxSelections,
-              cancellable: data.cancellable
+              cancellable: data.cancellable,
+              unselectableCards: data.unselectableCards,
             };
             break;
           }
@@ -1910,5 +1925,9 @@ export default {
 
 .card-action-group {
   display: flex;
+}
+
+.unselectable-card {
+  filter: brightness(50%)
 }
 </style>

--- a/webapp/src/views/Match.vue
+++ b/webapp/src/views/Match.vue
@@ -118,7 +118,7 @@
             <img
               @contextmenu.prevent="showLarge(card)"
               @dragstart.prevent=""
-              class="no-drag unselectable-card"
+              class="no-drag brightness-50 cursor-not-allowed"
               :src="`https://scans.shobu.io/${card.uid}.jpg`"
             />
           </div>
@@ -1925,9 +1925,5 @@ export default {
 
 .card-action-group {
   display: flex;
-}
-
-.unselectable-card {
-  filter: brightness(50%)
 }
 </style>


### PR DESCRIPTION
- When searching with a filter in a container you have now the option to display all the cards that don't match the filter as unselectable cards.
<img width="1423" alt="Screenshot 2024-08-18 at 12 50 36" src="https://github.com/user-attachments/assets/70aef88e-1a4d-4178-9d81-fa5ed80b5a32">
 
- fixes a few cards that enforced picking even though they had "may"
- updated encountered cards that used deprecated methods


Some refactoring can be done with all the NewAction, NewMultipartAction and so on methods, to clean them up a bit, but I didn't want to bloat more this PR, so I just implemented this in a very simple way.