### PR TITLE
Match chat player visual separation

### DIFF
--- a/game/cards/dm01/berserker.go
+++ b/game/cards/dm01/berserker.go
@@ -33,24 +33,28 @@ func RaylaTruthEnforcer(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		cards := fx.SelectFilterFullList(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.DECK,
+			"Select 1 spell from your deck that will be shown to your opponent and sent to your hand",
+			1,
+			1,
+			true,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+			true,
+		)
 
-			if event.CardID == card.ID && (event.To == match.BATTLEZONE || event.To == match.SPELLZONE) {
-
-				cards := match.SearchForCnd(card.Player, ctx.Match, card.Player, match.DECK, cnd.Spell, "Select 1 spell from your deck that will be shown to your opponent and sent to your hand", 1, 1, true)
-
-				for _, c := range cards {
-					card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
-					ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
-				}
-
-				card.Player.ShuffleDeck()
-
-			}
+		for _, c := range cards {
+			card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
+			ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
 		}
 
-	})
+		card.Player.ShuffleDeck()
+
+	}))
 
 }

--- a/game/cards/dm01/berserker.go
+++ b/game/cards/dm01/berserker.go
@@ -35,7 +35,7 @@ func RaylaTruthEnforcer(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		cards := fx.SelectFilterFullList(
+		cards := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm01/gel_fish.go
+++ b/game/cards/dm01/gel_fish.go
@@ -18,32 +18,13 @@ func IllusionaryMerfolk(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
-
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				battlezone, err := card.Player.Container(match.BATTLEZONE)
-
-				if err != nil {
-					return
-				}
-
-				for _, creature := range battlezone {
-
-					if creature.HasFamily(family.CyberLord) {
-						card.Player.DrawCards(3)
-						return
-					}
-
-				}
-
-			}
-
+		if match.ContainerHas(card.Player, match.BATTLEZONE, func(x *match.Card) bool { return x.HasFamily(family.CyberLord) }) {
+			fx.DrawUpTo3(card, ctx)
 		}
 
-	})
+	}))
 
 }
 

--- a/game/cards/dm01/leaviathan.go
+++ b/game/cards/dm01/leaviathan.go
@@ -45,6 +45,6 @@ func KingRippedHide(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Draw2)
+	c.Use(fx.Creature, fx.When(fx.Summoned, fx.DrawUpTo2))
 
 }

--- a/game/cards/dm01/spells.go
+++ b/game/cards/dm01/spells.go
@@ -39,15 +39,7 @@ func BrainSerum(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Spell, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
-
-		if match.AmICasted(card, ctx) {
-
-			card.Player.DrawCards(2)
-
-		}
-
-	})
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, fx.DrawUpTo2))
 
 }
 

--- a/game/cards/dm01/spells.go
+++ b/game/cards/dm01/spells.go
@@ -193,26 +193,21 @@ func CrystalMemory(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Spell, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmICasted(card, ctx) {
+		selectedCards := fx.Select(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 card from your deck that will be sent to your hand", 1, 1, true)
 
-			selectedCards := match.Search(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 card from your deck that will be sent to your hand", 1, 1, false)
+		for _, selectedCard := range selectedCards {
 
-			for _, selectedCard := range selectedCards {
-
-				card.Player.MoveCard(selectedCard.ID, match.DECK, match.HAND, card.ID)
-
-			}
-
-			card.Player.ShuffleDeck()
-
-			ctx.Match.Chat("Server", card.Player.Username()+" retrieved a card from their deck")
+			card.Player.MoveCard(selectedCard.ID, match.DECK, match.HAND, card.ID)
 
 		}
 
-	})
+		card.Player.ShuffleDeck()
 
+		ctx.Match.Chat("Server", card.Player.Username()+" retrieved a card from their deck")
+
+	}))
 }
 
 // DarkReversal ...
@@ -276,24 +271,20 @@ func DimensionGate(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Spell, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmICasted(card, ctx) {
+		creatures := fx.SelectFilterFullList(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.HasCondition(cnd.Creature) }, true)
 
-			creatures := match.Filter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, false, func(x *match.Card) bool { return x.HasCondition(cnd.Creature) })
+		for _, creature := range creatures {
 
-			for _, creature := range creatures {
-
-				card.Player.MoveCard(creature.ID, match.DECK, match.HAND, card.ID)
-				ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from the deck to their hand", card.Player.Username(), creature.Name))
-
-			}
-
-			card.Player.ShuffleDeck()
+			card.Player.MoveCard(creature.ID, match.DECK, match.HAND, card.ID)
+			ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from the deck to their hand", card.Player.Username(), creature.Name))
 
 		}
 
-	})
+		card.Player.ShuffleDeck()
+
+	}))
 
 }
 

--- a/game/cards/dm01/spells.go
+++ b/game/cards/dm01/spells.go
@@ -273,7 +273,7 @@ func DimensionGate(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		creatures := fx.SelectFilterFullList(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.HasCondition(cnd.Creature) }, true)
+		creatures := fx.SelectFilter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.HasCondition(cnd.Creature) }, true)
 
 		for _, creature := range creatures {
 

--- a/game/cards/dm02/armored_wyvern.go
+++ b/game/cards/dm02/armored_wyvern.go
@@ -20,7 +20,7 @@ func MetalwingSkyterror(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),

--- a/game/cards/dm02/berserker.go
+++ b/game/cards/dm02/berserker.go
@@ -23,7 +23,7 @@ func LagunaLightningEnforcer(c *match.Card) {
 
 		ctx.ScheduleAfter(func() {
 
-			fx.SelectFilter(card.Player,
+			fx.SelectFilterFullList(card.Player,
 				ctx.Match,
 				card.Player,
 				match.DECK,
@@ -32,6 +32,7 @@ func LagunaLightningEnforcer(c *match.Card) {
 				1,
 				true,
 				func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+				true,
 			).Map(func(x *match.Card) {
 				x.Player.MoveCard(x.ID, match.DECK, match.HAND, card.ID)
 				ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from their deck to their hand", x.Player.Username(), x.Name))

--- a/game/cards/dm02/berserker.go
+++ b/game/cards/dm02/berserker.go
@@ -23,7 +23,7 @@ func LagunaLightningEnforcer(c *match.Card) {
 
 		ctx.ScheduleAfter(func() {
 
-			fx.SelectFilterFullList(card.Player,
+			fx.SelectFilter(card.Player,
 				ctx.Match,
 				card.Player,
 				match.DECK,

--- a/game/cards/dm02/brain_jacker.go
+++ b/game/cards/dm02/brain_jacker.go
@@ -23,7 +23,7 @@ func AmberPiercer(c *match.Card) {
 
 		ctx.ScheduleAfter(func() {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm02/cyber_lord.go
+++ b/game/cards/dm02/cyber_lord.go
@@ -18,13 +18,7 @@ func HypersquidWalter(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
-
-		ctx.ScheduleAfter(func() {
-			card.Player.DrawCards(1)
-		})
-
-	}))
+	c.Use(fx.Creature, fx.When(fx.Attacking, fx.MayDraw1))
 
 }
 

--- a/game/cards/dm02/cyber_lord.go
+++ b/game/cards/dm02/cyber_lord.go
@@ -80,7 +80,7 @@ func Corile(c *match.Card) {
 
 			ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action...")
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				ctx.Match.Opponent(card.Player),
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm02/cyber_virus.go
+++ b/game/cards/dm02/cyber_virus.go
@@ -22,7 +22,7 @@ func StainedGlass(c *match.Card) {
 
 		ctx.ScheduleAfter(func() {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm02/gel_fish.go
+++ b/game/cards/dm02/gel_fish.go
@@ -39,7 +39,7 @@ func PlasmaChaser(c *match.Card) {
 			return
 		}
 
-		card.Player.DrawCards(toDraw)
+		fx.MayDrawAmount(card, ctx, toDraw)
 
 	}))
 

--- a/game/cards/dm02/guardian.go
+++ b/game/cards/dm02/guardian.go
@@ -35,7 +35,7 @@ func PhalEegaDawnGuardian(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm02/horned_beast.go
+++ b/game/cards/dm02/horned_beast.go
@@ -19,22 +19,29 @@ func RumblingTerahorn(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmISummoned(card, ctx) {
+		cards := fx.SelectFilterFullList(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.DECK,
+			"Select 1 creature from your deck that will be shown to your opponent and sent to your hand",
+			1,
+			1,
+			true,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Creature) },
+			true,
+		)
 
-			cards := match.SearchForCnd(card.Player, ctx.Match, card.Player, match.DECK, cnd.Creature, "Select 1 creature from your deck that will be shown to your opponent and sent to your hand", 1, 1, true)
-
-			for _, c := range cards {
-				card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
-				ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
-			}
-
-			card.Player.ShuffleDeck()
-
+		for _, c := range cards {
+			card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
+			ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
 		}
 
-	})
+		card.Player.ShuffleDeck()
+
+	}))
 
 }
 

--- a/game/cards/dm02/horned_beast.go
+++ b/game/cards/dm02/horned_beast.go
@@ -21,7 +21,7 @@ func RumblingTerahorn(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		cards := fx.SelectFilterFullList(
+		cards := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm02/initiate.go
+++ b/game/cards/dm02/initiate.go
@@ -17,6 +17,6 @@ func MagrisVizierOfMagnetism(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Draw1)
+	c.Use(fx.Creature, fx.When(fx.Summoned, fx.MayDraw1))
 
 }

--- a/game/cards/dm02/parasite_worm.go
+++ b/game/cards/dm02/parasite_worm.go
@@ -76,7 +76,7 @@ func PoisonWorm(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm02/spells.go
+++ b/game/cards/dm02/spells.go
@@ -64,24 +64,31 @@ func LogicCube(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Spell, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmICasted(card, ctx) {
+		creatures := fx.SelectFilterFullList(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.DECK,
+			"Select 1 spell from your deck that will be shown to your opponent and sent to your hand",
+			1,
+			1,
+			true,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+			true,
+		)
 
-			creatures := match.Filter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 spell from your deck that will be shown to your opponent and sent to your hand", 1, 1, false, func(x *match.Card) bool { return x.HasCondition(cnd.Spell) })
+		for _, creature := range creatures {
 
-			for _, creature := range creatures {
-
-				card.Player.MoveCard(creature.ID, match.DECK, match.HAND, card.ID)
-				ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from the deck to their hand", card.Player.Username(), creature.Name))
-
-			}
-
-			card.Player.ShuffleDeck()
+			card.Player.MoveCard(creature.ID, match.DECK, match.HAND, card.ID)
+			ctx.Match.Chat("Server", fmt.Sprintf("%s retrieved %s from the deck to their hand", card.Player.Username(), creature.Name))
 
 		}
 
-	})
+		card.Player.ShuffleDeck()
+
+	}))
 
 }
 

--- a/game/cards/dm02/spells.go
+++ b/game/cards/dm02/spells.go
@@ -66,7 +66,7 @@ func LogicCube(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		creatures := fx.SelectFilterFullList(
+		creatures := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -125,7 +125,7 @@ func CriticalBlade(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),

--- a/game/cards/dm03/balloon_mushroom.go
+++ b/game/cards/dm03/balloon_mushroom.go
@@ -19,7 +19,7 @@ func Psyshroom(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm03/brain_jacker.go
+++ b/game/cards/dm03/brain_jacker.go
@@ -23,7 +23,7 @@ func BonePiercer(c *match.Card) {
 
 		ctx.Match.Wait(ctx.Match.Opponent(c.Player), "Waiting for your opponent to make an action")
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm03/colony_beetle.go
+++ b/game/cards/dm03/colony_beetle.go
@@ -22,7 +22,7 @@ func PouchShell(c *match.Card) {
 
 		if match.AmISummoned(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm03/gel_fish.go
+++ b/game/cards/dm03/gel_fish.go
@@ -27,7 +27,7 @@ func ChaosFish(c *match.Card) {
 
 		ctx.ScheduleAfter(func() {
 			nrCardsToDraw := (getWaterCardsInYourBattleZone(card) - 1) //-1 to exclude self
-			card.Player.DrawCards(nrCardsToDraw)
+			fx.DrawBetween(card, ctx, 0, nrCardsToDraw)
 		})
 	}))
 

--- a/game/cards/dm03/ghost.go
+++ b/game/cards/dm03/ghost.go
@@ -29,7 +29,7 @@ func JackViperShadowofDoom(c *match.Card) {
 			event.Card.Player == card.Player &&
 			event.Card.Civ == civ.Darkness {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm03/giant_insect.go
+++ b/game/cards/dm03/giant_insect.go
@@ -29,7 +29,7 @@ func Gigamantis(c *match.Card) {
 			event.Card.Player == card.Player &&
 			event.Card.Civ == civ.Nature {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm03/leviathan.go
+++ b/game/cards/dm03/leviathan.go
@@ -97,7 +97,7 @@ func KingPonitas(c *match.Card) {
 	c.Use(fx.Creature, fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
 
 		ctx.ScheduleAfter(func() {
-			waterCards := match.Filter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 wated card from your deck that will be shown to your opponent and sent to your hand", 1, 1, false, func(x *match.Card) bool { return x.Civ == civ.Water })
+			waterCards := fx.SelectFilterFullList(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 water card from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.Civ == civ.Water }, true)
 
 			for _, waterCard := range waterCards {
 

--- a/game/cards/dm03/leviathan.go
+++ b/game/cards/dm03/leviathan.go
@@ -97,7 +97,7 @@ func KingPonitas(c *match.Card) {
 	c.Use(fx.Creature, fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
 
 		ctx.ScheduleAfter(func() {
-			waterCards := fx.SelectFilterFullList(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 water card from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.Civ == civ.Water }, true)
+			waterCards := fx.SelectFilter(card.Player, ctx.Match, card.Player, match.DECK, "Select 1 water card from your deck that will be shown to your opponent and sent to your hand", 1, 1, true, func(x *match.Card) bool { return x.Civ == civ.Water }, true)
 
 			for _, waterCard := range waterCards {
 

--- a/game/cards/dm03/spells.go
+++ b/game/cards/dm03/spells.go
@@ -70,7 +70,7 @@ func SundropArmor(c *match.Card) {
 
 		if match.AmICasted(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,
@@ -396,7 +396,7 @@ func VolcanicArrows(c *match.Card) {
 				ctx.Match.MoveCard(x, match.GRAVEYARD, card)
 			})
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),
@@ -487,7 +487,7 @@ func RoarOfTheEarth(c *match.Card) {
 
 		if match.AmICasted(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm04/cyber_virus.go
+++ b/game/cards/dm04/cyber_virus.go
@@ -17,11 +17,7 @@ func AstralWarper(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Evolution, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
-		
-		//TODO: let the player select between 0 and 3
-		card.Player.DrawCards(3)
-	}))
+	c.Use(fx.Creature, fx.Evolution, fx.When(fx.Summoned, fx.DrawUpTo3))
 }
 
 // KeeperOfTheSunlitAbyss ...
@@ -35,13 +31,13 @@ func KeeperOfTheSunlitAbyss(c *match.Card) {
 	c.ManaRequirement = []string{civ.Water}
 
 	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
-		
+
 		if card.Zone != match.BATTLEZONE {
 			return
 		}
 
 		if event, ok := ctx.Event.(*match.GetPowerEvent); ok {
-			
+
 			if event.Card.Civ == civ.Light || event.Card.Civ == civ.Darkness {
 				event.Power += 1000
 			}

--- a/game/cards/dm04/giant_insect.go
+++ b/game/cards/dm04/giant_insect.go
@@ -30,7 +30,7 @@ func ThreeEyedDragonfly(c *match.Card) {
 			// reset this before each attack attempt
 			selectedCard = ""
 
-			cards := fx.SelectFilter(
+			cards := fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm04/guardian.go
+++ b/game/cards/dm04/guardian.go
@@ -5,7 +5,6 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
-	"fmt"
 )
 
 // GulanRiasSpeedGuardian ...
@@ -39,34 +38,5 @@ func MistRiasSonicGuardian(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
-
-		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
-			if card.Zone != match.BATTLEZONE {
-
-				exit()
-				return
-			}
-
-			if event, ok := ctx2.Event.(*match.CardMoved); ok && event.To == match.BATTLEZONE && event.CardID != card.ID {
-
-				if !ctx2.Match.IsPlayerTurn(card.Player) {
-					ctx2.Match.Wait(ctx2.Match.Opponent(card.Player), "Waiting for your opponent to make an action")
-					defer ctx2.Match.EndWait(ctx2.Match.Opponent(card.Player))
-				}
-
-				result := fx.SelectBacksideFilter(card.Player, ctx2.Match, card.Player, match.BATTLEZONE, fmt.Sprintf("%s: You may draw a card. Click close to not draw a card.", card.Name), 1, 1, true, func(x *match.Card) bool {
-					return x.ID == c.ID
-				})
-
-				if len(result) > 0 {
-					card.Player.DrawCards(1)
-					ctx2.Match.Chat("Server", fmt.Sprintf("%s chose to draw a card from %s's ability", card.Player.Username(), card.Name))
-				}
-			}
-
-		})
-
-	}))
+	c.Use(fx.Creature, fx.When(fx.AnotherCreatureSummoned, fx.MayDraw1))
 }

--- a/game/cards/dm04/hedrian.go
+++ b/game/cards/dm04/hedrian.go
@@ -5,7 +5,6 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
-	"fmt"
 )
 
 // Locomotiver ...
@@ -31,40 +30,6 @@ func MongrelMan(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
-
-		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
-			if card.Zone != match.BATTLEZONE {
-
-				exit()
-				return
-
-			}
-
-			if event, ok := ctx2.Event.(*match.CardMoved); ok &&
-				event.From == match.BATTLEZONE &&
-				event.To == match.GRAVEYARD &&
-				event.CardID != card.ID {
-
-				if !ctx2.Match.IsPlayerTurn(card.Player) {
-					ctx2.Match.Wait(ctx2.Match.Opponent(card.Player), "Waiting for your opponent to make an action")
-					defer ctx2.Match.EndWait(ctx2.Match.Opponent(card.Player))
-				}
-
-				result := fx.SelectBacksideFilter(card.Player, ctx2.Match, card.Player, match.BATTLEZONE, fmt.Sprintf("%s: You may draw a card. Click close to not draw a card.", card.Name), 1, 1, true, func(x *match.Card) bool {
-					return x.ID == c.ID
-				})
-
-				if len(result) > 0 {
-					card.Player.DrawCards(1)
-					ctx2.Match.Chat("Server", fmt.Sprintf("%s chose to draw a card from %s's ability", card.Player.Username(), card.Name))
-				}
-
-			}
-
-		})
-
-	}))
+	c.Use(fx.Creature, fx.When(fx.AnotherCreatureDestroyed, fx.MayDraw1))
 
 }

--- a/game/cards/dm04/horned_beast.go
+++ b/game/cards/dm04/horned_beast.go
@@ -21,7 +21,7 @@ func NiofaHornedProtector(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		cards := match.Filter(
+		cards := fx.SelectFilterFullList(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -31,6 +31,7 @@ func NiofaHornedProtector(c *match.Card) {
 			1,
 			false,
 			func(x *match.Card) bool { return x.HasCondition(cnd.Creature) && x.Civ == civ.Nature },
+			true,
 		)
 
 		for _, c := range cards {

--- a/game/cards/dm04/horned_beast.go
+++ b/game/cards/dm04/horned_beast.go
@@ -21,7 +21,7 @@ func NiofaHornedProtector(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		cards := fx.SelectFilterFullList(
+		cards := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm04/living_dead.go
+++ b/game/cards/dm04/living_dead.go
@@ -20,7 +20,7 @@ func SkeletonThiefTheRevealer(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm04/rock_beast.go
+++ b/game/cards/dm04/rock_beast.go
@@ -22,7 +22,7 @@ func DoboulgyserGiantRockBeast(c *match.Card) {
 
 		if match.AmISummoned(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm04/spells.go
+++ b/game/cards/dm04/spells.go
@@ -84,7 +84,7 @@ func MegaDetonator(c *match.Card) {
 
 		n := 0
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm05/angel_command.go
+++ b/game/cards/dm05/angel_command.go
@@ -35,7 +35,7 @@ func SyforceAuroraElemental(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Blocker, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm05/fire_bird.go
+++ b/game/cards/dm05/fire_bird.go
@@ -29,7 +29,7 @@ func KipChippotto(c *match.Card) {
 			event.Card.Player == card.Player &&
 			event.Card.HasFamily(family.ArmoredDragon) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm05/gel_fish.go
+++ b/game/cards/dm05/gel_fish.go
@@ -52,7 +52,7 @@ func SplitHeadHydroturtleQ(c *match.Card) {
 		}
 
 		if creature.HasCondition(cnd.Survivor) {
-			creature.Player.DrawCards(1)
+			fx.MayDraw1(card, ctx)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s drew a card when %s attacked due to %s's survivor ability", card.Player.Username(), creature.Name, card.Name))
 		}
 

--- a/game/cards/dm05/giant_insect.go
+++ b/game/cards/dm05/giant_insect.go
@@ -52,7 +52,7 @@ func ScissorScarab(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterFullList(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -61,7 +61,9 @@ func ScissorScarab(c *match.Card) {
 			1,
 			1,
 			true,
-			func(c *match.Card) bool { return c.HasFamily(family.GiantInsect) }).Map(func(c *match.Card) {
+			func(c *match.Card) bool { return c.HasFamily(family.GiantInsect) },
+			true,
+		).Map(func(c *match.Card) {
 			card.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", c.Name, card.Player.Username()))
 		})

--- a/game/cards/dm05/giant_insect.go
+++ b/game/cards/dm05/giant_insect.go
@@ -21,7 +21,7 @@ func BloodwingMantis(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -52,7 +52,7 @@ func ScissorScarab(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilterFullList(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -86,7 +86,7 @@ func AmbushScorpion(c *match.Card) {
 
 	c.Use(fx.Creature, fx.PowerAttacker3000, fx.When(fx.Destroyed, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -124,7 +124,7 @@ func ObsidianScarab(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Doublebreaker, fx.PowerAttacker3000, fx.When(fx.Destroyed, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm05/spells.go
+++ b/game/cards/dm05/spells.go
@@ -248,6 +248,9 @@ func MiracleQuest(c *match.Card) {
 	cardPlayed := false
 	shieldsBroken := 0
 
+	// TODO: This implementation needs improving
+	// It currently has a big draw at the end of turn, instead of multiple ones after each attack
+	// It also counts shields that an opponent might destroy by himself which it shouldn't
 	c.Use(
 		fx.Spell,
 		fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
@@ -263,8 +266,7 @@ func MiracleQuest(c *match.Card) {
 		fx.When(fx.EndOfMyTurn, func(card *match.Card, ctx *match.Context) {
 
 			if cardPlayed {
-
-				card.Player.DrawCards(shieldsBroken * 2)
+				fx.MayDrawAmount(card, ctx, shieldsBroken*2)
 
 				cardPlayed = false
 				shieldsBroken = 0

--- a/game/cards/dm05/spells.go
+++ b/game/cards/dm05/spells.go
@@ -210,7 +210,7 @@ func BrutalCharge(c *match.Card) {
 
 			if cardPlayed {
 
-				fx.SelectFilter(
+				fx.SelectFilterFullList(
 					card.Player,
 					ctx.Match,
 					card.Player,
@@ -220,6 +220,7 @@ func BrutalCharge(c *match.Card) {
 					shieldsBroken,
 					true,
 					func(c *match.Card) bool { return c.HasCondition(cnd.Creature) },
+					true,
 				).Map(func(c *match.Card) {
 					c.Player.MoveCard(c.ID, match.DECK, match.HAND, card.ID)
 					ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand by %s", c.Name, c.Player.Username(), card.Name))

--- a/game/cards/dm05/spells.go
+++ b/game/cards/dm05/spells.go
@@ -20,7 +20,7 @@ func EnchantedSoil(c *match.Card) {
 
 		if match.AmICasted(card, ctx) {
 
-			fx.SelectFilter(card.Player, ctx.Match, card.Player, match.GRAVEYARD, "Enchanted Soil: Select 2 creatures from your graveyard and put it in your manazone", 0, 2, true, func(x *match.Card) bool {
+			fx.SelectFilterSelectablesOnly(card.Player, ctx.Match, card.Player, match.GRAVEYARD, "Enchanted Soil: Select 2 creatures from your graveyard and put it in your manazone", 0, 2, true, func(x *match.Card) bool {
 				return x.HasCondition(cnd.Creature)
 			}).Map(func(c *match.Card) {
 				card.Player.MoveCard(c.ID, match.GRAVEYARD, match.MANAZONE, card.ID)
@@ -210,7 +210,7 @@ func BrutalCharge(c *match.Card) {
 
 			if cardPlayed {
 
-				fx.SelectFilterFullList(
+				fx.SelectFilter(
 					card.Player,
 					ctx.Match,
 					card.Player,

--- a/game/cards/dm06/colony_beetle.go
+++ b/game/cards/dm06/colony_beetle.go
@@ -60,7 +60,7 @@ func FactoryShellQ(c *match.Card) {
 				return
 			}
 
-			fx.SelectFilter(
+			fx.SelectFilterFullList(
 				card.Player,
 				ctx.Match,
 				card.Player,
@@ -70,6 +70,7 @@ func FactoryShellQ(c *match.Card) {
 				1,
 				true,
 				func(x *match.Card) bool { return x.HasCondition(cnd.Survivor) },
+				true,
 			).Map(func(x *match.Card) {
 				card.Player.MoveCard(x.ID, match.DECK, match.HAND, card.ID)
 				ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", x.Name, card.Player.Username()))

--- a/game/cards/dm06/colony_beetle.go
+++ b/game/cards/dm06/colony_beetle.go
@@ -60,7 +60,7 @@ func FactoryShellQ(c *match.Card) {
 				return
 			}
 
-			fx.SelectFilterFullList(
+			fx.SelectFilter(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm06/dragonoid.go
+++ b/game/cards/dm06/dragonoid.go
@@ -78,7 +78,7 @@ func LavaWalkerExecuto(c *match.Card) {
 }
 
 func lavaWalkerExecutoTapAbility(card *match.Card, ctx *match.Context) {
-	creatures := fx.SelectFilter(
+	creatures := fx.SelectFilterSelectablesOnly(
 		card.Player,
 		ctx.Match,
 		card.Player,

--- a/game/cards/dm06/ghost.go
+++ b/game/cards/dm06/ghost.go
@@ -65,7 +65,7 @@ func GrimSoulShadowOfReversal(c *match.Card) {
 	c.ManaRequirement = []string{civ.Darkness}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -36,7 +36,7 @@ func ForbosSanctumGuardianQ(c *match.Card) {
 				return
 			}
 
-			fx.SelectFilter(
+			fx.SelectFilterFullList(
 				card.Player,
 				ctx.Match,
 				card.Player,
@@ -46,6 +46,7 @@ func ForbosSanctumGuardianQ(c *match.Card) {
 				1,
 				true,
 				func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+				true,
 			).Map(func(x *match.Card) {
 				card.Player.MoveCard(x.ID, match.DECK, match.HAND, card.ID)
 				ctx.Match.Chat("Server", fmt.Sprintf("%s was moved from %s's deck to their hand", x.Name, card.Player.Username()))

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -36,7 +36,7 @@ func ForbosSanctumGuardianQ(c *match.Card) {
 				return
 			}
 
-			fx.SelectFilterFullList(
+			fx.SelectFilter(
 				card.Player,
 				ctx.Match,
 				card.Player,

--- a/game/cards/dm06/human.go
+++ b/game/cards/dm06/human.go
@@ -22,7 +22,7 @@ func ArmoredDecimatorValkaizer(c *match.Card) {
 
 		if match.AmISummoned(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),

--- a/game/cards/dm06/parasite_worm.go
+++ b/game/cards/dm06/parasite_worm.go
@@ -33,7 +33,7 @@ func GraveWormQ(c *match.Card) {
 			}
 
 			if creature.HasFamily(family.Survivor) && event.To == match.BATTLEZONE {
-				fx.SelectFilter(
+				fx.SelectFilterSelectablesOnly(
 					card.Player,
 					ctx.Match,
 					card.Player,

--- a/game/cards/dm06/rainbow_phantom.go
+++ b/game/cards/dm06/rainbow_phantom.go
@@ -18,7 +18,7 @@ func CosmogoldSpectralKnight(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Light}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm06/snow_faerie.go
+++ b/game/cards/dm06/snow_faerie.go
@@ -19,7 +19,7 @@ func CharmiliaTheEnticer(c *match.Card) {
 	c.ManaRequirement = []string{civ.Nature}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
-		cards := match.Filter(
+		cards := fx.SelectFilterFullList(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -29,6 +29,7 @@ func CharmiliaTheEnticer(c *match.Card) {
 			1,
 			false,
 			func(x *match.Card) bool { return x.HasCondition(cnd.Creature) },
+			true,
 		)
 
 		for _, c := range cards {

--- a/game/cards/dm06/snow_faerie.go
+++ b/game/cards/dm06/snow_faerie.go
@@ -19,7 +19,7 @@ func CharmiliaTheEnticer(c *match.Card) {
 	c.ManaRequirement = []string{civ.Nature}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 
-		cards := fx.SelectFilterFullList(
+		cards := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,

--- a/game/cards/dm06/spells.go
+++ b/game/cards/dm06/spells.go
@@ -62,7 +62,7 @@ func InvincibleTechnology(c *match.Card) {
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		selectedCards := match.Search(card.Player, ctx.Match, card.Player, match.DECK, "Select any number of cards from your deck that will be sent to your hand", 1, 100, false)
+		selectedCards := fx.Select(card.Player, ctx.Match, card.Player, match.DECK, "Select any number of cards from your deck that will be sent to your hand", 0, 100, false)
 
 		for _, selectedCard := range selectedCards {
 
@@ -316,7 +316,7 @@ func MysticTreasureChest(c *match.Card) {
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterFullList(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -325,7 +325,9 @@ func MysticTreasureChest(c *match.Card) {
 			1,
 			1,
 			true,
-			func(c *match.Card) bool { return c.Civ != civ.Nature }).Map(func(x *match.Card) {
+			func(c *match.Card) bool { return c.Civ != civ.Nature },
+			true,
+		).Map(func(x *match.Card) {
 			x.Player.MoveCard(x.ID, match.DECK, match.MANAZONE, card.ID)
 			ctx.Match.Chat("Server", fmt.Sprintf("%s put %s in their manazone from their deck", x.Player.Username(), x.Name))
 		})

--- a/game/cards/dm06/spells.go
+++ b/game/cards/dm06/spells.go
@@ -17,7 +17,7 @@ func ProtectiveForce(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -316,7 +316,7 @@ func MysticTreasureChest(c *match.Card) {
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilterFullList(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -348,7 +348,7 @@ func PangaeasWill(c *match.Card) {
 
 		if match.AmICasted(card, ctx) {
 
-			fx.SelectFilter(
+			fx.SelectFilterSelectablesOnly(
 				card.Player,
 				ctx.Match,
 				ctx.Match.Opponent(card.Player),
@@ -513,7 +513,7 @@ func CometMissile(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		creatures := fx.SelectFilter(
+		creatures := fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),

--- a/game/cards/dm06/survivor.go
+++ b/game/cards/dm06/survivor.go
@@ -27,7 +27,7 @@ func QTronicHypermind(c *match.Card) {
 			return
 		}
 
-		card.Player.DrawCards(toDraw)
+		fx.DrawBetween(card, ctx, 0, toDraw)
 
 	}))
 }

--- a/game/cards/dm06/xenoparts.go
+++ b/game/cards/dm06/xenoparts.go
@@ -29,7 +29,7 @@ func RikabusScrewdriver(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Fire}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
-		fx.SelectFilter(
+		fx.SelectFilterSelectablesOnly(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),

--- a/game/fx/creature.go
+++ b/game/fx/creature.go
@@ -130,7 +130,7 @@ func Creature(card *match.Card, ctx *match.Context) {
 					card.AddCondition(cnd.SummoningSickness, nil, nil)
 
 					card.Player.MoveCard(card.ID, match.HAND, match.BATTLEZONE, card.ID)
-					ctx.Match.Chat("Server", fmt.Sprintf("%s summoned %s to the battle zone", card.Player.Username(), card.Name))
+					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s summoned %s to the battle zone", card.Player.Username(), card.Name))
 
 				}
 
@@ -616,15 +616,15 @@ func Creature(card *match.Card, ctx *match.Context) {
 
 			if attackerPower > defenderPower {
 				m.HandleFx(match.NewContext(m, &match.CreatureDestroyed{Card: defender, Source: attacker, Blocked: blocked}))
-				m.Chat("Server", fmt.Sprintf("%s (%v) was destroyed by %s (%v)", defender.Name, defenderPower, attacker.Name, attackerPower))
+				m.ReportActionInChat(defender.Player, fmt.Sprintf("%s (%v) was destroyed by %s (%v)", defender.Name, defenderPower, attacker.Name, attackerPower))
 			} else if attackerPower == defenderPower {
 				m.HandleFx(match.NewContext(m, &match.CreatureDestroyed{Card: attacker, Source: defender, Blocked: blocked}))
-				m.Chat("Server", fmt.Sprintf("%s (%v) was destroyed by %s (%v)", attacker.Name, attackerPower, defender.Name, defenderPower))
+				m.ReportActionInChat(attacker.Player, fmt.Sprintf("%s (%v) was destroyed by %s (%v)", attacker.Name, attackerPower, defender.Name, defenderPower))
 				m.HandleFx(match.NewContext(m, &match.CreatureDestroyed{Card: defender, Source: attacker, Blocked: blocked}))
-				m.Chat("Server", fmt.Sprintf("%s (%v) was destroyed by %s (%v)", defender.Name, defenderPower, attacker.Name, attackerPower))
+				m.ReportActionInChat(defender.Player, fmt.Sprintf("%s (%v) was destroyed by %s (%v)", defender.Name, defenderPower, attacker.Name, attackerPower))
 			} else if attackerPower < defenderPower {
 				m.HandleFx(match.NewContext(m, &match.CreatureDestroyed{Card: attacker, Source: defender, Blocked: blocked}))
-				m.Chat("Server", fmt.Sprintf("%s (%v) was destroyed by %s (%v)", attacker.Name, attackerPower, defender.Name, defenderPower))
+				m.ReportActionInChat(attacker.Player, fmt.Sprintf("%s (%v) was destroyed by %s (%v)", attacker.Name, attackerPower, defender.Name, defenderPower))
 			}
 		})
 	}

--- a/game/fx/draw.go
+++ b/game/fx/draw.go
@@ -72,14 +72,42 @@ func DrawToMana(card *match.Card, ctx *match.Context) {
 }
 
 func MayDraw1(card *match.Card, ctx *match.Context) {
+	MayDrawAmount(card, ctx, 1)
+}
 
-	ctx.Match.NewAction(card.Player, nil, 0, 0, "Do you want to draw a card?", true)
+func DrawUpTo2(card *match.Card, ctx *match.Context) {
+	DrawBetween(card, ctx, 0, 2)
+}
 
-	action := <-card.Player.Action
+func DrawUpTo3(card *match.Card, ctx *match.Context) {
+	DrawBetween(card, ctx, 0, 3)
+}
 
-	if !action.Cancel {
-		draw(card, ctx, 1)
+// This gives the player the choice to select a number of cards to draw between 2 provided limits
+func DrawBetween(card *match.Card, ctx *match.Context, min int, max int) {
+	count := max
+	if min != max {
+		count = SelectCount(
+			card.Player,
+			ctx.Match,
+			fmt.Sprintf("%s effect: Draw between %d and %d cards", card.Name, min, max),
+			min,
+			max)
 	}
-	ctx.Match.CloseAction(card.Player)
+	card.Player.DrawCards(count)
+}
 
+// This lets the player choose if they want to draw the full amount or none
+func MayDrawAmount(card *match.Card, ctx *match.Context, amount int) {
+	drawAmount := 0
+	textAmount := fmt.Sprintf("%d cards", amount)
+	if amount == 1 {
+		textAmount = "1 card"
+	}
+
+	if BinaryQuestion(card.Player, ctx.Match, fmt.Sprintf("Do you want to draw %s? (%s effect)", textAmount, card.Name)) {
+		drawAmount = amount
+	}
+
+	card.Player.DrawCards(drawAmount)
 }

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -67,7 +67,15 @@ func Select(p *match.Player, m *match.Match, containerOwner *match.Player, conta
 }
 
 // SelectFilter prompts the user to select n cards from the specified container that matches the given filter
+//
+// Deprecated: New cards should use `fx.SelectFilterFullList`
 func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool) CardCollection {
+	return SelectFilterFullList(p, m, containerOwner, containerName, text, min, max, cancellable, filter, false)
+}
+
+// SelectFilter prompts the user to select n cards from the specified container that matches the given filter.
+// It also allows to show all the other cards from the container that are unselectable
+func SelectFilterFullList(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool, showUnselectables bool) CardCollection {
 
 	result := make([]*match.Card, 0)
 
@@ -78,10 +86,13 @@ func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player,
 	}
 
 	filtered := make([]*match.Card, 0)
+	unselectables := make([]*match.Card, 0)
 
 	for _, mCard := range cards {
 		if filter(mCard) {
 			filtered = append(filtered, mCard)
+		} else if showUnselectables {
+			unselectables = append(unselectables, mCard)
 		}
 	}
 
@@ -89,7 +100,7 @@ func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player,
 		return result
 	}
 
-	m.NewAction(p, filtered, min, max, text, cancellable)
+	m.NewActionFullList(p, filtered, min, max, text, cancellable, unselectables)
 
 	defer m.CloseAction(p)
 

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -66,6 +66,52 @@ func Select(p *match.Player, m *match.Match, containerOwner *match.Player, conta
 	return SelectFilterSelectablesOnly(p, m, containerOwner, containerName, text, min, max, cancellable, func(x *match.Card) bool { return true })
 }
 
+// SelectCount prompts to user to select a number in an interval
+func SelectCount(p *match.Player, m *match.Match, text string, min int, max int) int {
+	result := 0
+
+	m.NewCountAction(p, text, min, max)
+
+	defer m.CloseAction(p)
+
+	if !m.IsPlayerTurn(p) {
+		m.Wait(m.Opponent(p), "Waiting for your opponent to make an action")
+		defer m.EndWait(m.Opponent(p))
+	}
+
+	for {
+
+		action := <-p.Action
+
+		if action.Count < min || action.Count > max {
+			m.ActionWarning(p, "The amount selected does not match the requirements")
+			continue
+		}
+
+		result = action.Count
+
+		break
+
+	}
+
+	return result
+}
+
+func BinaryQuestion(p *match.Player, m *match.Match, text string) bool {
+	m.NewQuestionAction(p, text)
+
+	defer m.CloseAction(p)
+
+	if !m.IsPlayerTurn(p) {
+		m.Wait(m.Opponent(p), "Waiting for your opponent to make an action")
+		defer m.EndWait(m.Opponent(p))
+	}
+
+	action := <-p.Action
+
+	return !action.Cancel
+}
+
 // SelectFilterSelectablesOnly prompts the user to select n cards from the specified container that matches the given filter
 //
 // Deprecated: New cards should use `fx.SelectFilter`
@@ -402,4 +448,35 @@ func ShieldBroken(card *match.Card, ctx *match.Context) bool {
 	_, ok := ctx.Event.(*match.BrokenShieldEvent)
 	return ok
 
+}
+
+func AnotherCreatureSummoned(card *match.Card, ctx *match.Context) bool {
+	if card.Zone != match.BATTLEZONE {
+		return false
+	}
+
+	if event, ok := ctx.Event.(*match.CardMoved); ok {
+
+		if event.CardID != card.ID && event.To == match.BATTLEZONE {
+			return true
+		}
+
+	}
+
+	return false
+}
+
+func AnotherCreatureDestroyed(card *match.Card, ctx *match.Context) bool {
+	if card.Zone != match.BATTLEZONE {
+		return false
+	}
+
+	if event, ok := ctx.Event.(*match.CardMoved); ok &&
+		event.From == match.BATTLEZONE &&
+		event.To == match.GRAVEYARD &&
+		event.CardID != card.ID {
+		return true
+	}
+
+	return false
 }

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -63,19 +63,19 @@ func When(test func(*match.Card, *match.Context) bool, h func(*match.Card, *matc
 
 // Select prompts the user to select n cards from the specified container
 func Select(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool) CardCollection {
-	return SelectFilter(p, m, containerOwner, containerName, text, min, max, cancellable, func(x *match.Card) bool { return true })
+	return SelectFilterSelectablesOnly(p, m, containerOwner, containerName, text, min, max, cancellable, func(x *match.Card) bool { return true })
 }
 
-// SelectFilter prompts the user to select n cards from the specified container that matches the given filter
+// SelectFilterSelectablesOnly prompts the user to select n cards from the specified container that matches the given filter
 //
-// Deprecated: New cards should use `fx.SelectFilterFullList`
-func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool) CardCollection {
-	return SelectFilterFullList(p, m, containerOwner, containerName, text, min, max, cancellable, filter, false)
+// Deprecated: New cards should use `fx.SelectFilter`
+func SelectFilterSelectablesOnly(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool) CardCollection {
+	return SelectFilter(p, m, containerOwner, containerName, text, min, max, cancellable, filter, false)
 }
 
 // SelectFilter prompts the user to select n cards from the specified container that matches the given filter.
 // It also allows to show all the other cards from the container that are unselectable
-func SelectFilterFullList(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool, showUnselectables bool) CardCollection {
+func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player, containerName string, text string, min int, max int, cancellable bool, filter func(*match.Card) bool, showUnselectables bool) CardCollection {
 
 	result := make([]*match.Card, 0)
 

--- a/game/fx/spell.go
+++ b/game/fx/spell.go
@@ -129,7 +129,7 @@ func Spell(card *match.Card, ctx *match.Context) {
 			return
 		}
 
-		ctx.Match.Chat("Server", fmt.Sprintf("%s played the spell %s", card.Player.Username(), card.Name))
+		ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s played the spell %s", card.Player.Username(), card.Name))
 
 		ctx.ScheduleAfter(func() {
 			card.Player.MoveCard(card.ID, match.HAND, match.GRAVEYARD, card.ID)

--- a/game/match/helpers.go
+++ b/game/match/helpers.go
@@ -74,7 +74,7 @@ func Search(p *Player, m *Match, containerOwner *Player, containerName string, t
 
 // SearchForCnd prompts the user to select n cards from the specified container that matches the given condition
 //
-// Deprecated: New cards should use `fx.SelectFilter`
+// Deprecated: New cards should use `fx.SelectFilterSelectablesOnly`
 func SearchForCnd(p *Player, m *Match, containerOwner *Player, containerName string, condition string, text string, min int, max int, cancellable bool) []*Card {
 
 	result := make([]*Card, 0)
@@ -135,7 +135,7 @@ func SearchForCnd(p *Player, m *Match, containerOwner *Player, containerName str
 
 // SearchForFamily prompts the user to select n cards from the specified container that matches the given family
 //
-// Deprecated: New cards should use `fx.SelectFilter`
+// Deprecated: New cards should use `fx.SelectFilterSelectablesOnly`
 func SearchForFamily(p *Player, m *Match, containerOwner *Player, containerName string, family string, text string, min int, max int, cancellable bool) []*Card {
 
 	result := make([]*Card, 0)
@@ -196,7 +196,7 @@ func SearchForFamily(p *Player, m *Match, containerOwner *Player, containerName 
 
 // Filter prompts the user to select n cards from the specified container that matches the given filter
 //
-// Deprecated: New cards should use `fx.SelectFilter`
+// Deprecated: New cards should use `fx.SelectFilterSelectablesOnly`
 func Filter(p *Player, m *Match, containerOwner *Player, containerName string, text string, min int, max int, cancellable bool, filter func(*Card) bool) []*Card {
 
 	result := make([]*Card, 0)

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -622,14 +622,19 @@ func (m *Match) HandleFx(ctx *Context) {
 
 // NewAction prompts the user to make a selection of the specified []Cards
 func (m *Match) NewAction(player *Player, cards []*Card, minSelections int, maxSelections int, text string, cancellable bool) {
+	m.NewActionFullList(player, cards, minSelections, maxSelections, text, cancellable, nil)
+}
+
+func (m *Match) NewActionFullList(player *Player, cards []*Card, minSelections int, maxSelections int, text string, cancellable bool, unselectableCards []*Card) {
 
 	msg := &server.ActionMessage{
-		Header:        "action",
-		Cards:         denormalizeCards(cards, false),
-		Text:          text,
-		MinSelections: minSelections,
-		MaxSelections: maxSelections,
-		Cancellable:   cancellable,
+		Header:            "action",
+		Cards:             denormalizeCards(cards, false),
+		Text:              text,
+		MinSelections:     minSelections,
+		MaxSelections:     maxSelections,
+		Cancellable:       cancellable,
+		UnselectableCards: denormalizeCards(unselectableCards, false),
 	}
 
 	player.ActionState = PlayerActionState{

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -198,15 +198,15 @@ func (m *Match) CastSpell(card *Card, fromShield bool) {
 	m.HandleFx(NewContext(m, &SpellCast{
 		CardID:        card.ID,
 		FromShield:    fromShield,
-		MatchPlayerID: m.getPlayerMatchId(card),
+		MatchPlayerID: m.getPlayerMatchId(card.Player),
 	}))
 
 	m.BroadcastState()
 
 }
 
-func (m *Match) getPlayerMatchId(card *Card) byte {
-	if card.Player == m.Player1.Player {
+func (m *Match) getPlayerMatchId(player *Player) byte {
+	if player == m.Player1.Player {
 		return 1
 	}
 	return 2
@@ -242,7 +242,7 @@ func (m *Match) MoveCard(card *Card, destination string, source *Card) {
 		return
 	}
 
-	m.Chat("Server", fmt.Sprintf("%s was moved to %s %s by %s", card.Name, card.Player.Username(), destination, source.Name))
+	m.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s %s by %s", card.Name, card.Player.Username(), destination, source.Name))
 
 }
 
@@ -415,6 +415,11 @@ func (m *Match) ColorChat(sender string, message string, color string) {
 	}
 
 	m.Broadcast(msg)
+}
+
+func (m *Match) ReportActionInChat(player *Player, message string) {
+	sender := fmt.Sprintf("Server_%d", m.getPlayerMatchId(player))
+	m.ColorChat(sender, message, "#ccc")
 }
 
 // Chat sends a chat message with the default color
@@ -878,7 +883,7 @@ func (m *Match) StartOfTurnStep() {
 
 	m.HandleFx(ctx)
 
-	m.Chat("Server", fmt.Sprintf("Your turn, %s", m.CurrentPlayer().Socket.User.Username))
+	m.ReportActionInChat(m.CurrentPlayer().Player, fmt.Sprintf("Your turn, %s", m.CurrentPlayer().Socket.User.Username))
 
 	m.DrawStep()
 
@@ -923,7 +928,7 @@ func (m *Match) EndStep() {
 
 	m.HandleFx(ctx)
 
-	m.Chat("Server", fmt.Sprintf("%s ended their turn", m.CurrentPlayer().Socket.User.Username))
+	m.ReportActionInChat(m.CurrentPlayer().Player, fmt.Sprintf("%s ended their turn", m.CurrentPlayer().Socket.User.Username))
 
 	m.EndOfTurnTriggers()
 
@@ -968,7 +973,7 @@ func (m *Match) ChargeMana(p *PlayerReference, cardID string) {
 	if card, err := p.Player.MoveCard(cardID, HAND, MANAZONE, cardID); err == nil {
 		p.Player.HasChargedMana = true
 		m.BroadcastState()
-		m.Chat("Server", fmt.Sprintf("%s was added to %s's manazone", card.Name, p.Socket.User.Username))
+		m.ReportActionInChat(p.Player, fmt.Sprintf("%s was added to %s's manazone", card.Name, p.Socket.User.Username))
 	}
 
 }

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -703,6 +703,44 @@ func (m *Match) newMultipartActionBase(player *Player, cards map[string][]*Card,
 
 }
 
+// NewCountAction prompts the user to select a number in an interval
+func (m *Match) NewCountAction(player *Player, text string, minSelections int, maxSelections int) {
+
+	msg := &server.ActionMessage{
+		Header:        "action",
+		ActionType:    "count",
+		Text:          text,
+		MinSelections: minSelections,
+		MaxSelections: maxSelections,
+	}
+
+	player.ActionState = PlayerActionState{
+		resolved: false,
+		data:     msg,
+	}
+
+	m.PlayerRef(player).Socket.Send(msg)
+
+}
+
+// NewQuestionAction prompts the user to answer a yes/no question
+func (m *Match) NewQuestionAction(player *Player, text string) {
+
+	msg := &server.ActionMessage{
+		Header:     "action",
+		ActionType: "question",
+		Text:       text,
+	}
+
+	player.ActionState = PlayerActionState{
+		resolved: false,
+		data:     msg,
+	}
+
+	m.PlayerRef(player).Socket.Send(msg)
+
+}
+
 // CloseAction closes the card selection popup for the given player
 func (m *Match) CloseAction(p *Player) {
 	p.ActionState.resolved = true
@@ -1835,7 +1873,7 @@ func (m *Match) handleAdminMesseges(message string, user db.User) {
 			count := 1
 			if len(msgParts) > 2 {
 				number, err := strconv.Atoi(msgParts[2])
-				if err == nil && number <= 5 || number >= 1 {
+				if err == nil && number >= 1 {
 					count = number
 				}
 			}

--- a/game/match/player.go
+++ b/game/match/player.go
@@ -347,9 +347,9 @@ func (p *Player) DrawCards(n int) {
 	}
 
 	if n == 1 {
-		p.match.Chat("Server", fmt.Sprintf("%s drew %v card", p.match.PlayerRef(p).Socket.User.Username, n))
+		p.match.ReportActionInChat(p, fmt.Sprintf("%s drew %v card", p.match.PlayerRef(p).Socket.User.Username, n))
 	} else {
-		p.match.Chat("Server", fmt.Sprintf("%s drew %v cards", p.match.PlayerRef(p).Socket.User.Username, n))
+		p.match.ReportActionInChat(p, fmt.Sprintf("%s drew %v cards", p.match.PlayerRef(p).Socket.User.Username, n))
 	}
 
 	if len(p.deck) <= 0 {
@@ -476,7 +476,7 @@ func (p *Player) MoveCard(cardID string, from string, to string, source string) 
 		From:          from,
 		To:            to,
 		Source:        source,
-		MatchPlayerID: p.match.getPlayerMatchId(ref),
+		MatchPlayerID: p.match.getPlayerMatchId(ref.Player),
 	}))
 
 	return ref, nil

--- a/game/match/player.go
+++ b/game/match/player.go
@@ -46,6 +46,7 @@ type Spectator struct {
 // PlayerAction is the parsed response we retrieve after prompting the client for a selection of cards
 type PlayerAction struct {
 	Cards  []string `json:"cards"`
+	Count  int      `json:"count"`
 	Cancel bool     `json:"cancel"`
 }
 
@@ -345,10 +346,10 @@ func (p *Player) DrawCards(n int) {
 		p.MoveCard(card, DECK, HAND, "draw")
 	}
 
-	if n > 1 {
-		p.match.Chat("Server", fmt.Sprintf("%s drew %v cards", p.match.PlayerRef(p).Socket.User.Username, n))
-	} else {
+	if n == 1 {
 		p.match.Chat("Server", fmt.Sprintf("%s drew %v card", p.match.PlayerRef(p).Socket.User.Username, n))
+	} else {
+		p.match.Chat("Server", fmt.Sprintf("%s drew %v cards", p.match.PlayerRef(p).Socket.User.Username, n))
 	}
 
 	if len(p.deck) <= 0 {

--- a/server/messages.go
+++ b/server/messages.go
@@ -68,6 +68,7 @@ type WarningMessage struct {
 // ActionMessage is used to prompt the user to make a selection of the specified cards
 type ActionMessage struct {
 	Header            string      `json:"header"`
+	ActionType        string      `json:"actionType"`
 	Cards             []CardState `json:"cards"`
 	Text              string      `json:"text"`
 	MinSelections     int         `json:"minSelections"`

--- a/server/messages.go
+++ b/server/messages.go
@@ -67,12 +67,13 @@ type WarningMessage struct {
 
 // ActionMessage is used to prompt the user to make a selection of the specified cards
 type ActionMessage struct {
-	Header        string      `json:"header"`
-	Cards         []CardState `json:"cards"`
-	Text          string      `json:"text"`
-	MinSelections int         `json:"minSelections"`
-	MaxSelections int         `json:"maxSelections"`
-	Cancellable   bool        `json:"cancellable"`
+	Header            string      `json:"header"`
+	Cards             []CardState `json:"cards"`
+	Text              string      `json:"text"`
+	MinSelections     int         `json:"minSelections"`
+	MaxSelections     int         `json:"maxSelections"`
+	Cancellable       bool        `json:"cancellable"`
+	UnselectableCards []CardState `json:"unselectableCards"`
 }
 
 // MultipartActionMessage is used to prompt the user to make a selection of the specified cards

--- a/webapp/public/assets/images/left-arrow.svg
+++ b/webapp/public/assets/images/left-arrow.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#5865F2" width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke="#5865F2" transform="matrix(1, 0, 0, 1, 0, 0)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="m4.431 12.822 13 9A1 1 0 0 0 19 21V3a1 1 0 0 0-1.569-.823l-13 9a1.003 1.003 0 0 0 0 1.645z"/>
+</g>
+</svg>

--- a/webapp/public/assets/images/right-arrow.svg
+++ b/webapp/public/assets/images/right-arrow.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#5865F2" width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke="#5865F2" transform="matrix(-1, 0, 0, 1, 0, 0)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="m4.431 12.822 13 9A1 1 0 0 0 19 21V3a1 1 0 0 0-1.569-.823l-13 9a1.003 1.003 0 0 0 0 1.645z"/>
+</g>
+</svg>

--- a/webapp/src/views/Match.vue
+++ b/webapp/src/views/Match.vue
@@ -109,6 +109,20 @@
             />
           </div>
         </div>
+        <div v-for="(card, index) in action.unselectableCards" :key="index" class="card">
+          <div class="action-shield-number">
+            <span>{{
+              state.me.shieldMap[card.virtualId] ||
+              state.opponent.shieldMap[card.virtualId]
+            }}</span>
+            <img
+              @contextmenu.prevent="showLarge(card)"
+              @dragstart.prevent=""
+              class="no-drag unselectable-card"
+              :src="`https://scans.shobu.io/${card.uid}.jpg`"
+            />
+          </div>
+        </div>
       </div>
       <div v-if="actionObject && action.cards" class="action-cards">
         <div
@@ -1232,7 +1246,8 @@ export default {
               text: data.text,
               minSelection: data.minSelection,
               maxSelections: data.maxSelections,
-              cancellable: data.cancellable
+              cancellable: data.cancellable,
+              unselectableCards: data.unselectableCards,
             };
             break;
           }
@@ -1910,5 +1925,9 @@ export default {
 
 .card-action-group {
   display: flex;
+}
+
+.unselectable-card {
+  filter: brightness(50%)
 }
 </style>

--- a/webapp/src/views/Match.vue
+++ b/webapp/src/views/Match.vue
@@ -118,7 +118,7 @@
             <img
               @contextmenu.prevent="showLarge(card)"
               @dragstart.prevent=""
-              class="no-drag unselectable-card"
+              class="no-drag brightness-50 cursor-not-allowed"
               :src="`https://scans.shobu.io/${card.uid}.jpg`"
             />
           </div>
@@ -1925,9 +1925,5 @@ export default {
 
 .card-action-group {
   display: flex;
-}
-
-.unselectable-card {
-  filter: brightness(50%)
 }
 </style>

--- a/webapp/src/views/Match.vue
+++ b/webapp/src/views/Match.vue
@@ -76,26 +76,91 @@
     <!-- action (card selection) -->
     <div v-if="action" id="action" class="action noselect">
       <span v-draggable data-ref="action">{{ action.text }}</span>
-      <span v-if="action.cards && action.maxSelections > 0"
-        ><i> Tip: click and drag to (de)select faster</i></span
-      >
-      <template v-if="actionObject">
-        <select class="action-select" v-model="actionDrowdownSelection">
-          <option
+      <template v-if="action.actionType == 'count'">
+        <div class="flex justify-center mb-4">
+          <img
+            class="h-8"
+            :class="{'inactive-svg-button' : actionCount == action.minSelections}"
+            @click="modifyActionCount(-1)"
+            src="/assets/images/left-arrow.svg"
+          />
+          <input
+            class="ml-2 mr-2 w-4 bg-white pointer-events-none text-center" 
+            v-model.number="actionCount" 
+            :disabled="true"
+          />
+          <img
+            class="h-8"
+            :class="{'inactive-svg-button' : actionCount == action.maxSelections}"
+            @click="modifyActionCount(1)"
+            src="/assets/images/right-arrow.svg"
+          />
+        </div>
+        <div @click="chooseDrawAction()" class="btn">Draw {{ actionCount }}</div>
+      </template>
+      <template v-else-if="action.actionType == 'question'">
+        <div @click="chooseAction()" class="btn">
+          Yes
+        </div>
+        <div @click="cancelAction()" class="btn">
+          No
+        </div>
+      </template>
+      <template v-else>
+        <span v-if="action.cards && action.maxSelections > 0">
+          <i> Tip: click and drag to (de)select faster</i>
+        </span>
+        <template v-if="actionObject">
+          <select class="action-select" v-model="actionDrowdownSelection">
+            <option
             v-for="(option, index) in actionObject"
             :key="index"
             :value="index"
             >{{ index }}</option
-          >
-        </select>
-      </template>
-      <div v-if="!actionObject && action.cards" class="action-cards">
-        <div v-for="(card, index) in action.cards" :key="index" class="card">
-          <div class="action-shield-number">
-            <span>{{
-              state.me.shieldMap[card.virtualId] ||
+            >
+          </select>
+        </template>
+        <div v-if="!actionObject && action.cards" class="action-cards">
+          <div v-for="(card, index) in action.cards" :key="index" class="card">
+            <div class="action-shield-number">
+              <span>{{
+                state.me.shieldMap[card.virtualId] ||
                 state.opponent.shieldMap[card.virtualId]
-            }}</span>
+              }}</span>
+            <img
+            @contextmenu.prevent="showLarge(card)"
+            @dragstart.prevent=""
+            @mouseenter="actionSelectMouseEnter($event, card)"
+            @mousedown="actionSelect(card)"
+            :class="[
+              'no-drag',
+              actionSelects.includes(card) ? 'glow-' + card.civilization : ''
+            ]"
+              :src="`https://scans.shobu.io/${card.uid}.jpg`"
+              />
+            </div>
+          </div>
+          <div v-for="(card, index) in action.unselectableCards" :key="index" class="card">
+            <div class="action-shield-number">
+              <span>{{
+                state.me.shieldMap[card.virtualId] ||
+                state.opponent.shieldMap[card.virtualId]
+              }}</span>
+            <img
+            @contextmenu.prevent="showLarge(card)"
+            @dragstart.prevent=""
+            class="no-drag brightness-50 cursor-not-allowed"
+            :src="`https://scans.shobu.io/${card.uid}.jpg`"
+            />
+            </div>
+          </div>
+        </div>
+        <div v-if="actionObject && action.cards" class="action-cards">
+          <div
+            v-for="(card, index) in actionObject[actionDrowdownSelection]"
+            :key="index"
+            class="card"
+          >
             <img
               @contextmenu.prevent="showLarge(card)"
               @dragstart.prevent=""
@@ -106,51 +171,19 @@
                 actionSelects.includes(card) ? 'glow-' + card.civilization : ''
               ]"
               :src="`https://scans.shobu.io/${card.uid}.jpg`"
-            />
+              />
           </div>
+          <p v-if="actionObject[actionDrowdownSelection].length < 1">
+            There's no cards in this category. Use the dropdown above to switch
+            category.
+          </p>
         </div>
-        <div v-for="(card, index) in action.unselectableCards" :key="index" class="card">
-          <div class="action-shield-number">
-            <span>{{
-              state.me.shieldMap[card.virtualId] ||
-              state.opponent.shieldMap[card.virtualId]
-            }}</span>
-            <img
-              @contextmenu.prevent="showLarge(card)"
-              @dragstart.prevent=""
-              class="no-drag brightness-50 cursor-not-allowed"
-              :src="`https://scans.shobu.io/${card.uid}.jpg`"
-            />
-          </div>
+        <div @click="chooseAction()" class="btn">Choose</div>
+        <div @click="cancelAction()" v-if="action.cancellable" class="btn">
+          Close
         </div>
-      </div>
-      <div v-if="actionObject && action.cards" class="action-cards">
-        <div
-          v-for="(card, index) in actionObject[actionDrowdownSelection]"
-          :key="index"
-          class="card"
-        >
-          <img
-            @contextmenu.prevent="showLarge(card)"
-            @dragstart.prevent=""
-            @mouseenter="actionSelectMouseEnter($event, card)"
-            @mousedown="actionSelect(card)"
-            :class="[
-              'no-drag',
-              actionSelects.includes(card) ? 'glow-' + card.civilization : ''
-            ]"
-            :src="`https://scans.shobu.io/${card.uid}.jpg`"
-          />
-        </div>
-        <p v-if="actionObject[actionDrowdownSelection].length < 1">
-          There's no cards in this category. Use the dropdown above to switch
-          category.
-        </p>
-      </div>
-      <div @click="chooseAction()" class="btn">Choose</div>
-      <div @click="cancelAction()" v-if="action.cancellable" class="btn">
-        Close
-      </div>
+      </template>
+
       <span style="color: red">{{ actionError }}</span>
     </div>
 
@@ -762,6 +795,7 @@ export default {
       actionSelects: [],
       actionObject: null,
       actionDrowdownSelection: null,
+      actionCount: null,
 
       previewCard: null,
       previewCards: null,
@@ -889,6 +923,22 @@ export default {
         cards.push(card.virtualId);
       }
       this.ws.send(JSON.stringify({ header: "action", cards, cancel: false }));
+    },
+
+    chooseDrawAction() {
+      if (!this.action) {
+        return;
+      }
+      this.ws.send(JSON.stringify({ header: "action", count: this.actionCount, cancel: false }));
+    },
+
+    modifyActionCount(modifier) {
+      var newCount = this.actionCount + modifier
+      if (newCount > this.action.maxSelections || newCount < this.action.minSelections) {
+        // Play sound for reaching limit here if needed
+        return;
+      }  
+      this.actionCount = newCount 
     },
 
     addToManazone() {
@@ -1233,22 +1283,41 @@ export default {
 
           case "action": {
             (this.actionError = ""), (this.actionSelects = []);
-            if (!(data.cards instanceof Array)) {
-              this.actionObject = data.cards;
-              console.log(Object.keys(data.cards)[0]);
-              this.actionDrowdownSelection = Object.keys(data.cards)[0];
+
+            switch (data.actionType) {
+              case 'count':
+                this.actionCount = data.maxSelections
+                this.action = {
+                  text: data.text,
+                  minSelections: data.minSelections,
+                  maxSelections: data.maxSelections,
+                  actionType: data.actionType,
+                };
+                break
+              case 'question':
+                this.action = {
+                  text: data.text,
+                  actionType: data.actionType,
+                  cancellable: true,
+                };
+                break
+              default: 
+                if (!(data.cards instanceof Array)) {
+                  this.actionObject = data.cards;
+                  this.actionDrowdownSelection = Object.keys(data.cards)[0];
+                }
+                this.action = {
+                  cards:
+                    data.cards instanceof Array
+                      ? data.cards
+                      : Object.keys(data.cards)[0],
+                  text: data.text,
+                  minSelection: data.minSelection,
+                  maxSelections: data.maxSelections,
+                  cancellable: data.cancellable,
+                  unselectableCards: data.unselectableCards,
+                };
             }
-            this.action = {
-              cards:
-                data.cards instanceof Array
-                  ? data.cards
-                  : Object.keys(data.cards)[0],
-              text: data.text,
-              minSelection: data.minSelection,
-              maxSelections: data.maxSelections,
-              cancellable: data.cancellable,
-              unselectableCards: data.unselectableCards,
-            };
             break;
           }
 
@@ -1925,5 +1994,13 @@ export default {
 
 .card-action-group {
   display: flex;
+}
+
+.active-svg-button {
+  color: #5865F2;
+}
+
+.inactive-svg-button {
+  filter: grayscale(10); 
 }
 </style>

--- a/webapp/src/views/Match.vue
+++ b/webapp/src/views/Match.vue
@@ -222,16 +222,14 @@
         :style="playmat ? 'background: url(/assets/images/overlay_30.png)' : ''"
       >
         <div class="messages">
-          <div id="messages" class="messages-helper">
+          <div id="messages" class="messages-helper flex flex-col">
             <div
               class="message"
-              :style="{
-                background:
-                  message.sender.toLowerCase() === 'server'
-                    ? 'none'
-                    : playmat
-                    ? 'url(/assets/images/overlay_30.png)'
-                    : '#202124'
+              :class="{
+                'server_action_player_1': message.sender.toLowerCase() === 'server_1',
+                'server_action_player_2': message.sender.toLowerCase() === 'server_2',
+                'chat-message': !isFromServer(message) && !playmat,
+                'chat-message-playmat': !isFromServer(message) && playmat,
               }"
               v-for="(message, index) in chatMessages.filter(
                 m => !settings.muted.includes(m.sender)
@@ -241,6 +239,8 @@
               <div
                 class="message-sender"
                 :style="{ color: message.color || 'orange' }"
+                v-if="message.sender.toLowerCase() != 'server_1' && 
+                      message.sender.toLowerCase() != 'server_2'"
               >
                 {{
                   message.sender.toLowerCase() == "server"
@@ -252,7 +252,7 @@
               <div class="mute-icon-container">
                 <MuteIcon
                   v-if="
-                    !['server', username].includes(message.sender.toLowerCase())
+                    !['server', 'server_1', 'server_2', username].includes(message.sender.toLowerCase())
                   "
                   :player="message.sender"
                   @toggled="onSettingsChanged()"
@@ -829,6 +829,18 @@ export default {
         let container = document.getElementById("messages");
         container.scrollTop = container.scrollHeight;
       });
+    },
+
+    isFromServer(messageObj){
+      let sender = messageObj.sender.toLowerCase()
+      if ( 
+        sender === 'server' ||
+        sender === 'server_1' ||
+        sender === 'server_2'
+      )
+        return true;
+
+      return false;
     },
 
     onSettingsChanged(e) {
@@ -2002,5 +2014,25 @@ export default {
 
 .inactive-svg-button {
   filter: grayscale(10); 
+}
+
+.server_action_player_1 {
+  max-width: 80%;
+  align-self: flex-start;
+  background: rgba(181, 124, 60, 0.4)
+}
+
+.server_action_player_2 {
+  max-width: 80%;
+  align-self: flex-end;
+  background: rgba(124, 127, 143, 0.5)
+}
+
+.chat-message {
+  background: #202124
+}
+
+.chat-message-playmat {
+  background: rgba(0, 0, 0, 0.3)
 }
 </style>


### PR DESCRIPTION
Dependent on https://github.com/sindreslungaard/duel-masters/pull/248

Continuation in https://github.com/sindreslungaard/duel-masters/pull/256

Adds visual separation of action messages in the match chat between the actions of the 2 players, making it more clear what is happening.

For now only targets the base action message, while the specific cards ones remain untouched. They can be added step by step if this is approved.

<img width="1434" alt="Screenshot 2024-09-08 at 16 36 48" src="https://github.com/user-attachments/assets/ca53ee95-503a-46a8-9627-a674fdfd399e">
<img width="1435" alt="Screenshot 2024-09-08 at 16 53 33" src="https://github.com/user-attachments/assets/ac7f980a-d537-43b2-898e-bd7cd45c464e">
(second pic in a firefox browser)

