### PR TITLE
Fix top of evo cards removal

### DIFF
--- a/game/cards/dm01/armored_wyvern.go
+++ b/game/cards/dm01/armored_wyvern.go
@@ -46,46 +46,38 @@ func ScarletSkyterror(c *match.Card) {
 	c.ManaCost = 8
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		blockers := make([]*match.Card, 0)
 
-			if event.CardID != card.ID || event.To != match.BATTLEZONE {
-				return
-			}
+		myBattlezone, err := card.Player.Container(match.BATTLEZONE)
 
-			blockers := make([]*match.Card, 0)
-
-			myBattlezone, err := card.Player.Container(match.BATTLEZONE)
-
-			if err != nil {
-				return
-			}
-
-			opponentBattlezone, err := ctx.Match.Opponent(card.Player).Container(match.BATTLEZONE)
-
-			if err != nil {
-				return
-			}
-
-			for _, creature := range myBattlezone {
-				if creature.HasCondition(cnd.Blocker) {
-					blockers = append(blockers, creature)
-				}
-			}
-
-			for _, creature := range opponentBattlezone {
-				if creature.HasCondition(cnd.Blocker) {
-					blockers = append(blockers, creature)
-				}
-			}
-
-			for _, blocker := range blockers {
-				ctx.Match.Destroy(blocker, card, match.DestroyedByMiscAbility)
-			}
-
+		if err != nil {
+			return
 		}
 
-	})
+		opponentBattlezone, err := ctx.Match.Opponent(card.Player).Container(match.BATTLEZONE)
+
+		if err != nil {
+			return
+		}
+
+		for _, creature := range myBattlezone {
+			if creature.HasCondition(cnd.Blocker) {
+				blockers = append(blockers, creature)
+			}
+		}
+
+		for _, creature := range opponentBattlezone {
+			if creature.HasCondition(cnd.Blocker) {
+				blockers = append(blockers, creature)
+			}
+		}
+
+		for _, blocker := range blockers {
+			ctx.Match.Destroy(blocker, card, match.DestroyedByMiscAbility)
+		}
+
+	}))
 
 }

--- a/game/cards/dm01/armorloid.go
+++ b/game/cards/dm01/armorloid.go
@@ -42,31 +42,23 @@ func RothusTheTraveler(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		creatures := match.Search(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Rothus, the Traveler: Select 1 creature from your battlezone that will be sent to your graveyard", 1, 1, false)
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				creatures := match.Search(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Rothus, the Traveler: Select 1 creature from your battlezone that will be sent to your graveyard", 1, 1, false)
-
-				for _, creature := range creatures {
-					ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
-				}
-
-				ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action")
-				defer ctx.Match.EndWait(card.Player)
-
-				opponentCreatures := match.Search(ctx.Match.Opponent(card.Player), ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Rothus, the Traveler: Select 1 creature from your battlezone that will be sent to your graveyard", 1, 1, false)
-
-				for _, creature := range opponentCreatures {
-					ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
-				}
-
-			}
-
+		for _, creature := range creatures {
+			ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
 		}
 
-	})
+		ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action")
+		defer ctx.Match.EndWait(card.Player)
+
+		opponentCreatures := match.Search(ctx.Match.Opponent(card.Player), ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Rothus, the Traveler: Select 1 creature from your battlezone that will be sent to your graveyard", 1, 1, false)
+
+		for _, creature := range opponentCreatures {
+			ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
+		}
+
+	}))
 
 }

--- a/game/cards/dm01/beast_folk.go
+++ b/game/cards/dm01/beast_folk.go
@@ -59,7 +59,7 @@ func BronzeArmTribe(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.DrawToMana)
+	c.Use(fx.Creature, fx.When(fx.Summoned, fx.Draw1ToMana))
 
 }
 

--- a/game/cards/dm01/colony_beetle.go
+++ b/game/cards/dm01/colony_beetle.go
@@ -32,59 +32,51 @@ func StormShell(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		opponent := ctx.Match.Opponent(card.Player)
 
-			if event.CardID != card.ID || event.To != match.BATTLEZONE {
-				return
+		battlezone, err := opponent.Container(match.BATTLEZONE)
+
+		if err != nil {
+			return
+		}
+
+		if len(battlezone) < 1 {
+			return
+		}
+
+		ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action")
+
+		ctx.Match.NewAction(opponent, battlezone, 1, 1, "Storm Shell: Select 1 card from your battlezone that will be sent to your manazone", false)
+
+		defer func() {
+			ctx.Match.EndWait(card.Player)
+			ctx.Match.CloseAction(opponent)
+		}()
+
+		for {
+
+			action := <-opponent.Action
+
+			if len(action.Cards) != 1 || !match.AssertCardsIn(battlezone, action.Cards...) {
+				ctx.Match.ActionWarning(opponent, "Your selection of cards does not fulfill the requirements")
+				continue
 			}
 
-			opponent := ctx.Match.Opponent(card.Player)
-
-			battlezone, err := opponent.Container(match.BATTLEZONE)
+			movedCard, err := opponent.MoveCard(action.Cards[0], match.BATTLEZONE, match.MANAZONE, card.ID)
 
 			if err != nil {
-				return
-			}
-
-			if len(battlezone) < 1 {
-				return
-			}
-
-			ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action")
-
-			ctx.Match.NewAction(opponent, battlezone, 1, 1, "Storm Shell: Select 1 card from your battlezone that will be sent to your manazone", false)
-
-			defer func() {
-				ctx.Match.EndWait(card.Player)
-				ctx.Match.CloseAction(opponent)
-			}()
-
-			for {
-
-				action := <-opponent.Action
-
-				if len(action.Cards) != 1 || !match.AssertCardsIn(battlezone, action.Cards...) {
-					ctx.Match.ActionWarning(opponent, "Your selection of cards does not fulfill the requirements")
-					continue
-				}
-
-				movedCard, err := opponent.MoveCard(action.Cards[0], match.BATTLEZONE, match.MANAZONE, card.ID)
-
-				if err != nil {
-					break
-				}
-
-				ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was moved from %s's battlezone to their manazone", movedCard.Name, opponent.Username()))
-
 				break
-
 			}
+
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was moved from %s's battlezone to their manazone", movedCard.Name, opponent.Username()))
+
+			break
 
 		}
 
-	})
+	}))
 
 }
 

--- a/game/cards/dm01/dark_lord.go
+++ b/game/cards/dm01/dark_lord.go
@@ -17,46 +17,38 @@ func VampireSilphy(c *match.Card) {
 	c.ManaCost = 8
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		opponent := ctx.Match.Opponent(card.Player)
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				opponent := ctx.Match.Opponent(card.Player)
-
-				myCreatures, err := card.Player.Container(match.BATTLEZONE)
-				if err != nil {
-					return
-				}
-
-				opponentCreatures, err := opponent.Container(match.BATTLEZONE)
-				if err != nil {
-					return
-				}
-
-				toDestroy := make([]*match.Card, 0)
-
-				for _, creature := range myCreatures {
-					if ctx.Match.GetPower(creature, false) <= 3000 {
-						toDestroy = append(toDestroy, creature)
-					}
-				}
-
-				for _, creature := range opponentCreatures {
-					if ctx.Match.GetPower(creature, false) <= 3000 {
-						toDestroy = append(toDestroy, creature)
-					}
-				}
-
-				for _, creature := range toDestroy {
-					ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
-				}
-
-			}
-
+		myCreatures, err := card.Player.Container(match.BATTLEZONE)
+		if err != nil {
+			return
 		}
 
-	})
+		opponentCreatures, err := opponent.Container(match.BATTLEZONE)
+		if err != nil {
+			return
+		}
+
+		toDestroy := make([]*match.Card, 0)
+
+		for _, creature := range myCreatures {
+			if ctx.Match.GetPower(creature, false) <= 3000 {
+				toDestroy = append(toDestroy, creature)
+			}
+		}
+
+		for _, creature := range opponentCreatures {
+			if ctx.Match.GetPower(creature, false) <= 3000 {
+				toDestroy = append(toDestroy, creature)
+			}
+		}
+
+		for _, creature := range toDestroy {
+			ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
+		}
+
+	}))
 
 }

--- a/game/cards/dm01/dragonoid.go
+++ b/game/cards/dm01/dragonoid.go
@@ -32,22 +32,16 @@ func ExplosiveFighterUcarn(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.Doublebreaker, func(card *match.Card, ctx *match.Context) {
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
+		cards := match.Search(card.Player, ctx.Match, card.Player, match.MANAZONE, "Explosive Fighter Ucarn: Select 2 cards from your manazone that will be sent to your graveyard", 2, 2, false)
 
-				cards := match.Search(card.Player, ctx.Match, card.Player, match.MANAZONE, "Explosive Fighter Ucarn: Select 2 cards from your manazone that will be sent to your graveyard", 2, 2, false)
-
-				for _, manaCard := range cards {
-					card.Player.MoveCard(manaCard.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
-					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent from %s's manazone to their graveyard", manaCard.ID, card.Name))
-				}
-
-			}
-
+		for _, manaCard := range cards {
+			card.Player.MoveCard(manaCard.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent from %s's manazone to their graveyard", manaCard.ID, card.Name))
 		}
-	})
+
+	}))
 
 }
 
@@ -75,22 +69,16 @@ func OnslaughterTriceps(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
+		cards := match.Search(card.Player, ctx.Match, card.Player, match.MANAZONE, "Onslaughter Triceps: Select 1 card from your manazone that will be sent to your graveyard", 1, 1, false)
 
-				cards := match.Search(card.Player, ctx.Match, card.Player, match.MANAZONE, "Onslaughter Triceps: Select 1 card from your manazone that will be sent to your graveyard", 1, 1, false)
-
-				for _, manaCard := range cards {
-					card.Player.MoveCard(manaCard.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
-					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent from %s's manazone to their graveyard", manaCard.Name, card.Player.Username()))
-				}
-
-			}
-
+		for _, manaCard := range cards {
+			card.Player.MoveCard(manaCard.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent from %s's manazone to their graveyard", manaCard.Name, card.Player.Username()))
 		}
-	})
+
+	}))
 
 }
 

--- a/game/cards/dm01/fish.go
+++ b/game/cards/dm01/fish.go
@@ -46,76 +46,68 @@ func UnicornFish(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		cards := make(map[string][]*match.Card)
 
-			if event.CardID != card.ID || event.To != match.BATTLEZONE {
-				return
+		myCards, err := card.Player.Container(match.BATTLEZONE)
+
+		if err != nil {
+			return
+		}
+
+		opponentCards, err := ctx.Match.Opponent(card.Player).Container(match.BATTLEZONE)
+
+		if err != nil {
+			return
+		}
+
+		if len(myCards) < 1 && len(opponentCards) < 1 {
+			return
+		}
+
+		cards["Your creatures"] = myCards
+		cards["Opponent's creatures"] = opponentCards
+
+		ctx.Match.NewMultipartAction(card.Player, cards, 1, 1, "Unicorn Fish: Choose 1 creature in the battlezone that will be sent to its owners hands", true)
+
+		for {
+
+			action := <-card.Player.Action
+
+			if action.Cancel {
+				break
 			}
 
-			cards := make(map[string][]*match.Card)
-
-			myCards, err := card.Player.Container(match.BATTLEZONE)
-
-			if err != nil {
-				return
+			if len(action.Cards) != 1 {
+				ctx.Match.DefaultActionWarning(card.Player)
+				continue
 			}
 
-			opponentCards, err := ctx.Match.Opponent(card.Player).Container(match.BATTLEZONE)
+			for _, vid := range action.Cards {
 
-			if err != nil {
-				return
-			}
+				ref, err := c.Player.MoveCard(vid, match.BATTLEZONE, match.HAND, card.ID)
 
-			if len(myCards) < 1 && len(opponentCards) < 1 {
-				return
-			}
+				if err != nil {
 
-			cards["Your creatures"] = myCards
-			cards["Opponent's creatures"] = opponentCards
+					ref, err := ctx.Match.Opponent(c.Player).MoveCard(vid, match.BATTLEZONE, match.HAND, card.ID)
 
-			ctx.Match.NewMultipartAction(card.Player, cards, 1, 1, "Unicorn Fish: Choose 1 creature in the battlezone that will be sent to its owners hands", true)
-
-			for {
-
-				action := <-card.Player.Action
-
-				if action.Cancel {
-					break
-				}
-
-				if len(action.Cards) != 1 {
-					ctx.Match.DefaultActionWarning(card.Player)
-					continue
-				}
-
-				for _, vid := range action.Cards {
-
-					ref, err := c.Player.MoveCard(vid, match.BATTLEZONE, match.HAND, card.ID)
-
-					if err != nil {
-
-						ref, err := ctx.Match.Opponent(c.Player).MoveCard(vid, match.BATTLEZONE, match.HAND, card.ID)
-
-						if err == nil {
-							ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand", ref.Name, ctx.Match.PlayerRef(ref.Player).Socket.User.Username))
-						}
-
-					} else {
+					if err == nil {
 						ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand", ref.Name, ctx.Match.PlayerRef(ref.Player).Socket.User.Username))
 					}
 
+				} else {
+					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand", ref.Name, ctx.Match.PlayerRef(ref.Player).Socket.User.Username))
 				}
-
-				break
 
 			}
 
-			ctx.Match.CloseAction(c.Player)
+			break
 
 		}
 
-	})
+		ctx.Match.CloseAction(c.Player)
+
+	}))
 
 }

--- a/game/cards/dm01/gel_fish.go
+++ b/game/cards/dm01/gel_fish.go
@@ -66,40 +66,32 @@ func SaucerHeadShark(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
-
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				myBattlezone, err := card.Player.Container(match.BATTLEZONE)
-				if err != nil {
-					return
-				}
-
-				opponentBattlezone, err := ctx.Match.Opponent(card.Player).Container(match.BATTLEZONE)
-				if err != nil {
-					return
-				}
-
-				for _, creature := range myBattlezone {
-					if ctx.Match.GetPower(creature, false) <= 2000 {
-						creature.Player.MoveCard(creature.ID, match.BATTLEZONE, match.HAND, card.ID)
-						ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was returned to %s's hand by Saucer-Head Shark", creature.Name, creature.Player.Username()))
-					}
-				}
-
-				for _, creature := range opponentBattlezone {
-					if ctx.Match.GetPower(creature, false) <= 2000 {
-						creature.Player.MoveCard(creature.ID, match.BATTLEZONE, match.HAND, card.ID)
-						ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was returned to %s's hand by Saucer-Head Shark", creature.Name, creature.Player.Username()))
-					}
-				}
-
-			}
-
+		myBattlezone, err := card.Player.Container(match.BATTLEZONE)
+		if err != nil {
+			return
 		}
 
-	})
+		opponentBattlezone, err := ctx.Match.Opponent(card.Player).Container(match.BATTLEZONE)
+		if err != nil {
+			return
+		}
+
+		for _, creature := range myBattlezone {
+			if ctx.Match.GetPower(creature, false) <= 2000 {
+				creature.Player.MoveCard(creature.ID, match.BATTLEZONE, match.HAND, card.ID)
+				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was returned to %s's hand by Saucer-Head Shark", creature.Name, creature.Player.Username()))
+			}
+		}
+
+		for _, creature := range opponentBattlezone {
+			if ctx.Match.GetPower(creature, false) <= 2000 {
+				creature.Player.MoveCard(creature.ID, match.BATTLEZONE, match.HAND, card.ID)
+				ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was returned to %s's hand by Saucer-Head Shark", creature.Name, creature.Player.Username()))
+			}
+		}
+
+	}))
 
 }

--- a/game/cards/dm01/ghost.go
+++ b/game/cards/dm01/ghost.go
@@ -59,27 +59,25 @@ func BlackFeatherShadowOfRage(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmISummoned(card, ctx) {
+		ctx.ScheduleAfter(func() {
 
-			ctx.ScheduleAfter(func() {
-
-				fx.Select(
-					card.Player,
-					ctx.Match,
-					card.Player,
-					match.BATTLEZONE,
-					"Select one of your creatures that will be destroyed",
-					1,
-					1,
-					false,
-				).Map(func(x *match.Card) {
-					ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-				})
-
+			fx.Select(
+				card.Player,
+				ctx.Match,
+				card.Player,
+				match.BATTLEZONE,
+				"Select one of your creatures that will be destroyed",
+				1,
+				1,
+				false,
+			).Map(func(x *match.Card) {
+				ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
 			})
-		}
-	})
+
+		})
+
+	}))
 
 }

--- a/game/cards/dm01/initiate.go
+++ b/game/cards/dm01/initiate.go
@@ -60,23 +60,15 @@ func MieleVizierOfLightning(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		creatures := match.Search(card.Player, ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Miele, Vizier of Lightning: Select 1 of your opponent's creature and tap it. Close to not tap any creatures.", 1, 1, true)
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				creatures := match.Search(card.Player, ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Miele, Vizier of Lightning: Select 1 of your opponent's creature and tap it. Close to not tap any creatures.", 1, 1, true)
-
-				for _, creature := range creatures {
-					creature.Tapped = true
-				}
-
-			}
-
+		for _, creature := range creatures {
+			creature.Tapped = true
 		}
 
-	})
+	}))
 
 }
 

--- a/game/cards/dm01/parasite_worm.go
+++ b/game/cards/dm01/parasite_worm.go
@@ -17,23 +17,15 @@ func StingerWorm(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		creatures := match.Search(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Stinger Worm: Select 1 creature from your battlezone that will be sent to your graveyard", 1, 1, false)
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				creatures := match.Search(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Stinger Worm: Select 1 creature from your battlezone that will be sent to your graveyard", 1, 1, false)
-
-				for _, creature := range creatures {
-					ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
-				}
-
-			}
-
+		for _, creature := range creatures {
+			ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
 		}
 
-	})
+	}))
 
 }
 

--- a/game/cards/dm01/rock_beast.go
+++ b/game/cards/dm01/rock_beast.go
@@ -17,32 +17,25 @@ func Meteosaur(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		creatures := match.Filter(
+			card.Player,
+			ctx.Match,
+			ctx.Match.Opponent(card.Player),
+			match.BATTLEZONE,
+			"Meteosaur: Select 1 of your opponent's creatures with power 2000 or less and destroy it",
+			1,
+			1,
+			true,
+			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 2000 },
+		)
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				creatures := match.Filter(
-					card.Player,
-					ctx.Match,
-					ctx.Match.Opponent(card.Player),
-					match.BATTLEZONE,
-					"Meteosaur: Select 1 of your opponent's creatures with power 2000 or less and destroy it",
-					1,
-					1,
-					true,
-					func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 2000 },
-				)
-
-				for _, creature := range creatures {
-					ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
-				}
-
-			}
+		for _, creature := range creatures {
+			ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
 		}
 
-	})
+	}))
 
 }
 

--- a/game/cards/dm01/tree_folk.go
+++ b/game/cards/dm01/tree_folk.go
@@ -47,23 +47,16 @@ func ThornyMandra(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		creatures := match.SearchForCnd(card.Player, ctx.Match, card.Player, match.GRAVEYARD, cnd.Creature, "Thorny Mandra: Select 1 creature from your battlezone that will be sent to your manazone", 1, 1, true)
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				creatures := match.SearchForCnd(card.Player, ctx.Match, card.Player, match.GRAVEYARD, cnd.Creature, "Thorny Mandra: Select 1 creature from your battlezone that will be sent to your manazone", 1, 1, true)
-
-				for _, creature := range creatures {
-					creature.Tapped = false
-					card.Player.MoveCard(creature.ID, match.GRAVEYARD, match.MANAZONE, card.ID)
-					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved from %s's graveyard to their manazone", creature.Name, card.Player.Username()))
-				}
-
-			}
+		for _, creature := range creatures {
+			creature.Tapped = false
+			card.Player.MoveCard(creature.ID, match.GRAVEYARD, match.MANAZONE, card.ID)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved from %s's graveyard to their manazone", creature.Name, card.Player.Username()))
 		}
 
-	})
+	}))
 
 }

--- a/game/cards/dm02/beast_folk.go
+++ b/game/cards/dm02/beast_folk.go
@@ -46,7 +46,7 @@ func FighterDualFang(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.DrawToMana, fx.DrawToMana)
+	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.Summoned, fx.Draw2ToMana))
 
 }
 

--- a/game/cards/dm02/colony_beetle.go
+++ b/game/cards/dm02/colony_beetle.go
@@ -18,28 +18,24 @@ func FortressShell(c *match.Card) {
 	c.ManaCost = 9
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmISummoned(card, ctx) {
+		manaCards := match.Search(
+			card.Player,
+			ctx.Match,
+			ctx.Match.Opponent(card.Player),
+			match.MANAZONE,
+			"Select up to 2 cards in your opponent's mana zone that will be sent to their graveyard",
+			1,
+			2,
+			true,
+		)
 
-			manaCards := match.Search(
-				card.Player,
-				ctx.Match,
-				ctx.Match.Opponent(card.Player),
-				match.MANAZONE,
-				"Select up to 2 cards in your opponent's mana zone that will be sent to their graveyard",
-				1,
-				2,
-				true,
-			)
-
-			for _, mana := range manaCards {
-				ctx.Match.Opponent(card.Player).MoveCard(mana.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
-				ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was sent from %s's manazone to their graveyard by %s", mana.Name, mana.Player.Username(), card.Name))
-			}
-
+		for _, mana := range manaCards {
+			ctx.Match.Opponent(card.Player).MoveCard(mana.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was sent from %s's manazone to their graveyard by %s", mana.Name, mana.Player.Username(), card.Name))
 		}
 
-	})
+	}))
 
 }

--- a/game/cards/dm03/colony_beetle.go
+++ b/game/cards/dm03/colony_beetle.go
@@ -18,32 +18,29 @@ func PouchShell(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmISummoned(card, ctx) {
+		fx.SelectFilterSelectablesOnly(
+			card.Player,
+			ctx.Match,
+			ctx.Match.Opponent(card.Player),
+			match.BATTLEZONE,
+			"Pouch Shell: Select an evolution card from your opponent's battle zone and send the top card to their graveyard",
+			0,
+			1,
+			true,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Evolution) },
+		).Map(func(x *match.Card) {
+			tapped := x.Tapped
+			baseCard := x.Attachments()[0]
+			x.ClearAttachments()
+			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
+			baseCard.Player.MoveCard(baseCard.ID, match.HIDDENZONE, match.BATTLEZONE, card.ID)
+			if tapped && !baseCard.Tapped {
+				baseCard.Tapped = true
+			}
+		})
 
-			fx.SelectFilterSelectablesOnly(
-				card.Player,
-				ctx.Match,
-				ctx.Match.Opponent(card.Player),
-				match.BATTLEZONE,
-				"Pouch Shell: Select an evolution card from your opponent's battle zone and send the top card to their graveyard",
-				0,
-				1,
-				true,
-				func(x *match.Card) bool { return x.HasCondition(cnd.Evolution) },
-			).Map(func(x *match.Card) {
-				tapped := x.Tapped
-				baseCard := x.Attachments()[0]
-				x.ClearAttachments()
-				ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-				baseCard.Player.MoveCard(baseCard.ID, match.HIDDENZONE, match.BATTLEZONE, card.ID)
-				if tapped && !baseCard.Tapped {
-					baseCard.Tapped = true
-				}
-			})
-		}
-
-	})
+	}))
 
 }

--- a/game/cards/dm03/cyber_lord.go
+++ b/game/cards/dm03/cyber_lord.go
@@ -18,52 +18,44 @@ func Emeral(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		nrShields, err := card.Player.Container(match.SHIELDZONE)
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				nrShields, err := card.Player.Container(match.SHIELDZONE)
-
-				if err != nil {
-					return
-				}
-
-				if len(nrShields) < 1 {
-					return
-				}
-
-				toShield := match.Search(card.Player, ctx.Match, card.Player, match.HAND, "Emeral: You may select 1 card from your hand and put it into the shield zone", 0, 1, true)
-
-				if len(toShield) < 1 {
-					return
-				}
-
-				toHand := fx.SelectBackside(
-					card.Player,
-					ctx.Match,
-					card.Player,
-					match.SHIELDZONE,
-					"Emeral: Select 1 of your shields that will be moved to your hand",
-					1,
-					1,
-					false,
-				)
-
-				for _, card := range toShield {
-					card.Player.MoveCard(card.ID, match.HAND, match.SHIELDZONE, c.ID)
-				}
-
-				for _, card := range toHand {
-					card.Player.MoveCard(card.ID, match.SHIELDZONE, match.HAND, c.ID)
-				}
-
-			}
-
+		if err != nil {
+			return
 		}
 
-	})
+		if len(nrShields) < 1 {
+			return
+		}
+
+		toShield := match.Search(card.Player, ctx.Match, card.Player, match.HAND, "Emeral: You may select 1 card from your hand and put it into the shield zone", 0, 1, true)
+
+		if len(toShield) < 1 {
+			return
+		}
+
+		toHand := fx.SelectBackside(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.SHIELDZONE,
+			"Emeral: Select 1 of your shields that will be moved to your hand",
+			1,
+			1,
+			false,
+		)
+
+		for _, card := range toShield {
+			card.Player.MoveCard(card.ID, match.HAND, match.SHIELDZONE, c.ID)
+		}
+
+		for _, card := range toHand {
+			card.Player.MoveCard(card.ID, match.SHIELDZONE, match.HAND, c.ID)
+		}
+
+	}))
 
 }
 

--- a/game/cards/dm03/dark_lord.go
+++ b/game/cards/dm03/dark_lord.go
@@ -17,24 +17,21 @@ func BaragaBladeOfGloom(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmISummoned(card, ctx) {
+		fx.SelectBackside(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.SHIELDZONE,
+			"Baraga, Blade of Gloom: Move 1 of your shield to your hand.",
+			1,
+			1,
+			false,
+		).Map(func(x *match.Card) {
+			ctx.Match.MoveCard(x, match.HAND, card)
+		})
 
-			fx.SelectBackside(
-				card.Player,
-				ctx.Match,
-				card.Player,
-				match.SHIELDZONE,
-				"Baraga, Blade of Gloom: Move 1 of your shield to your hand.",
-				1,
-				1,
-				false,
-			).Map(func(x *match.Card) {
-				ctx.Match.MoveCard(x, match.HAND, card)
-			})
-
-		}
-	})
+	}))
 
 }

--- a/game/cards/dm03/initiate.go
+++ b/game/cards/dm03/initiate.go
@@ -43,7 +43,7 @@ func SiegBaliculaTheIntense(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Evolution, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Evolution, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 

--- a/game/cards/dm03/liquid_people.go
+++ b/game/cards/dm03/liquid_people.go
@@ -18,32 +18,24 @@ func AquaDeformer(c *match.Card) {
 	c.ManaCost = 8
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		cards := match.Search(card.Player, ctx.Match, card.Player, match.MANAZONE, "Aqua Deformer: Select 2 cards from your manazone that will be sent to your hand", 2, 2, false)
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
-
-				cards := match.Search(card.Player, ctx.Match, card.Player, match.MANAZONE, "Aqua Deformer: Select 2 cards from your manazone that will be sent to your hand", 2, 2, false)
-
-				for _, crd := range cards {
-					card.Player.MoveCard(crd.ID, match.MANAZONE, match.HAND, card.ID)
-					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand from their mana zone", crd.Name, ctx.Match.PlayerRef(card.Player).Socket.User.Username))
-				}
-
-				ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action")
-				defer ctx.Match.EndWait(card.Player)
-
-				opponentCards := match.Search(ctx.Match.Opponent(card.Player), ctx.Match, ctx.Match.Opponent(card.Player), match.MANAZONE, "Aqua Deformer: Select 2 cards from your manazone that will be sent to your hand", 2, 2, false)
-
-				for _, crd := range opponentCards {
-					ctx.Match.Opponent(card.Player).MoveCard(crd.ID, match.MANAZONE, match.HAND, card.ID)
-					ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was moved to %s's hand from their mana zone", crd.Name, ctx.Match.PlayerRef(ctx.Match.Opponent(card.Player)).Socket.User.Username))
-				}
-
-			}
-
+		for _, crd := range cards {
+			card.Player.MoveCard(crd.ID, match.MANAZONE, match.HAND, card.ID)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand from their mana zone", crd.Name, ctx.Match.PlayerRef(card.Player).Socket.User.Username))
 		}
 
-	})
+		ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action")
+		defer ctx.Match.EndWait(card.Player)
+
+		opponentCards := match.Search(ctx.Match.Opponent(card.Player), ctx.Match, ctx.Match.Opponent(card.Player), match.MANAZONE, "Aqua Deformer: Select 2 cards from your manazone that will be sent to your hand", 2, 2, false)
+
+		for _, crd := range opponentCards {
+			ctx.Match.Opponent(card.Player).MoveCard(crd.ID, match.MANAZONE, match.HAND, card.ID)
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was moved to %s's hand from their mana zone", crd.Name, ctx.Match.PlayerRef(ctx.Match.Opponent(card.Player)).Socket.User.Username))
+		}
+
+	}))
 }

--- a/game/cards/dm04/armored_dragon.go
+++ b/game/cards/dm04/armored_dragon.go
@@ -18,27 +18,25 @@ func GalklifeDragon(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.Doublebreaker, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmISummoned(card, ctx) {
+		fx.FindFilter(
+			card.Player,
+			match.BATTLEZONE,
+			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 4000 && x.Civ == civ.Light },
+		).Map(func(x *match.Card) {
+			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by Galklife Dragon", x.Name))
+		})
 
-			fx.FindFilter(
-				card.Player,
-				match.BATTLEZONE,
-				func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 4000 && x.Civ == civ.Light },
-			).Map(func(x *match.Card) {
-				ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by Galklife Dragon", x.Name))
-			})
+		fx.FindFilter(
+			ctx.Match.Opponent(card.Player),
+			match.BATTLEZONE,
+			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 4000 && x.Civ == civ.Light },
+		).Map(func(x *match.Card) {
+			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Galklife Dragon", x.Name))
+		})
 
-			fx.FindFilter(
-				ctx.Match.Opponent(card.Player),
-				match.BATTLEZONE,
-				func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 4000 && x.Civ == civ.Light },
-			).Map(func(x *match.Card) {
-				ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-				ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Galklife Dragon", x.Name))
-			})
-		}
-	})
+	}))
 }

--- a/game/cards/dm04/dark_lord.go
+++ b/game/cards/dm04/dark_lord.go
@@ -18,7 +18,7 @@ func GregoriaPrincessOfWar(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 
 			demonCommands := fx.FindFilter(

--- a/game/cards/dm04/ghost.go
+++ b/game/cards/dm04/ghost.go
@@ -18,7 +18,7 @@ func ShadowMoonCursedShade(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 

--- a/game/cards/dm04/leviathan.go
+++ b/game/cards/dm04/leviathan.go
@@ -18,33 +18,31 @@ func KingAquakamui(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature,
+		fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+			fx.FindFilter(
+				card.Player,
+				match.GRAVEYARD,
+				func(x *match.Card) bool { return x.HasFamily(family.AngelCommand) || x.HasFamily(family.DemonCommand) },
+			).Map(func(x *match.Card) {
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
+				x.Player.MoveCard(x.ID, match.GRAVEYARD, match.HAND, card.ID)
+				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand from their graveyard by King Aquakamui", x.Name, card.Player.Username()))
+			})
 
-				fx.FindFilter(
-					card.Player,
-					match.GRAVEYARD,
-					func(x *match.Card) bool { return x.HasFamily(family.AngelCommand) || x.HasFamily(family.DemonCommand) },
-				).Map(func(x *match.Card) {
+		}),
+		func(card *match.Card, ctx *match.Context) {
 
-					x.Player.MoveCard(x.ID, match.GRAVEYARD, match.HAND, card.ID)
-					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand from their graveyard by King Aquakamui", x.Name, card.Player.Username()))
-				})
+			if card.Zone != match.BATTLEZONE {
+				return
 			}
-		}
 
-		if card.Zone != match.BATTLEZONE {
-			return
-		}
+			if event, ok := ctx.Event.(*match.GetPowerEvent); ok {
 
-		if event, ok := ctx.Event.(*match.GetPowerEvent); ok {
-
-			if event.Card.HasFamily(family.AngelCommand) || event.Card.HasFamily(family.DemonCommand) {
-				event.Power += 2000
+				if event.Card.HasFamily(family.AngelCommand) || event.Card.HasFamily(family.DemonCommand) {
+					event.Power += 2000
+				}
 			}
-		}
-	})
+		})
 }

--- a/game/cards/dm04/mecha_thunder.go
+++ b/game/cards/dm04/mecha_thunder.go
@@ -39,7 +39,7 @@ func ReBilSeekerOfArchery(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 

--- a/game/cards/dm04/rock_beast.go
+++ b/game/cards/dm04/rock_beast.go
@@ -18,28 +18,25 @@ func DoboulgyserGiantRockBeast(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmISummoned(card, ctx) {
+		fx.SelectFilterSelectablesOnly(
+			card.Player,
+			ctx.Match,
+			ctx.Match.Opponent(card.Player),
+			match.BATTLEZONE,
+			"Doboulgyser: You may select 1 opponent's creature with 3000 or less power and destroy it.",
+			0,
+			1,
+			true,
+			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 3000 },
+		).Map(func(x *match.Card) {
 
-			fx.SelectFilterSelectablesOnly(
-				card.Player,
-				ctx.Match,
-				ctx.Match.Opponent(card.Player),
-				match.BATTLEZONE,
-				"Doboulgyser: You may select 1 opponent's creature with 3000 or less power and destroy it.",
-				0,
-				1,
-				true,
-				func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 3000 },
-			).Map(func(x *match.Card) {
+			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Doboulgyser", x.Name))
+		})
 
-				ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-				ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Doboulgyser", x.Name))
-			})
-
-		}
-	})
+	}))
 
 }
 

--- a/game/cards/dm04/rock_beast.go
+++ b/game/cards/dm04/rock_beast.go
@@ -53,33 +53,26 @@ func Magmarex(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.ShieldTrigger, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		fx.FindFilter(
+			card.Player,
+			match.BATTLEZONE,
+			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) == 1000 },
+		).Map(func(x *match.Card) {
+			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by Magmarex", x.Name))
+		})
 
-			if event.CardID != card.ID || event.To != match.BATTLEZONE {
-				return
-			}
+		fx.FindFilter(
+			ctx.Match.Opponent(card.Player),
+			match.BATTLEZONE,
+			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) == 1000 },
+		).Map(func(x *match.Card) {
+			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Magmarex", x.Name))
+		})
 
-			fx.FindFilter(
-				card.Player,
-				match.BATTLEZONE,
-				func(x *match.Card) bool { return ctx.Match.GetPower(x, false) == 1000 },
-			).Map(func(x *match.Card) {
-				ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by Magmarex", x.Name))
-			})
-
-			fx.FindFilter(
-				ctx.Match.Opponent(card.Player),
-				match.BATTLEZONE,
-				func(x *match.Card) bool { return ctx.Match.GetPower(x, false) == 1000 },
-			).Map(func(x *match.Card) {
-				ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-				ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Magmarex", x.Name))
-			})
-
-		}
-	})
+	}))
 
 }

--- a/game/cards/dm05/armored_wyvern.go
+++ b/game/cards/dm05/armored_wyvern.go
@@ -32,7 +32,7 @@ func BladerushSkyterrorQ(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.Survivor, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 

--- a/game/cards/dm05/chimera.go
+++ b/game/cards/dm05/chimera.go
@@ -107,7 +107,7 @@ func GigalingQ(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Survivor, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 			if card.Zone != match.BATTLEZONE {
 				fx.FindFilter(

--- a/game/cards/dm05/fish.go
+++ b/game/cards/dm05/fish.go
@@ -51,7 +51,7 @@ func SpikestrikeIchthysQ(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Survivor, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 

--- a/game/cards/dm05/guardian.go
+++ b/game/cards/dm05/guardian.go
@@ -45,7 +45,7 @@ func GalliaZohlIronGuardianQ(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Survivor, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 

--- a/game/cards/dm05/horned_beast.go
+++ b/game/cards/dm05/horned_beast.go
@@ -18,7 +18,7 @@ func SmashHornQ(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Survivor, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 

--- a/game/cards/dm05/rock_beast.go
+++ b/game/cards/dm05/rock_beast.go
@@ -18,7 +18,7 @@ func BlazosaurQ(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.Survivor, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 

--- a/game/cards/dm06/armorloid.go
+++ b/game/cards/dm06/armorloid.go
@@ -43,7 +43,7 @@ func ArmoredScoutGestuchar(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 			// Remove the conditions and exit the persistent effect when the card is no longer in the battle zone

--- a/game/cards/dm06/chimera.go
+++ b/game/cards/dm06/chimera.go
@@ -30,7 +30,7 @@ func PhantasmalHorrorGigazald(c *match.Card) {
 	c.TapAbility = fx.OpponentDiscardsRandomCard
 
 	c.Use(fx.Creature, fx.Evolution, fx.TapAbility,
-		fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+		fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 			fx.GiveTapAbilityToAllies(
 				card,

--- a/game/cards/dm06/colony_beetle.go
+++ b/game/cards/dm06/colony_beetle.go
@@ -85,7 +85,7 @@ func LivingCitadelVosh(c *match.Card) {
 	c.TapAbility = livingCitadelVoshTapAbility
 
 	c.Use(fx.Creature, fx.Evolution, fx.TapAbility,
-		fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+		fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 			fx.GiveTapAbilityToAllies(
 				card,

--- a/game/cards/dm06/colony_beetle.go
+++ b/game/cards/dm06/colony_beetle.go
@@ -42,35 +42,17 @@ func FactoryShellQ(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Survivor, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Survivor, fx.When(fx.MySurvivorSummoned, func(card *match.Card, ctx *match.Context) {
 
-		if !ctx.Match.IsPlayerTurn(card.Player) || card.Zone != match.BATTLEZONE {
-			return
-		}
+		fx.SearchDeckTakeCards(
+			card,
+			ctx,
+			1,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Survivor) },
+			"survivor",
+		)
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok && event.To == match.BATTLEZONE {
-
-			creature, err := card.Player.GetCard(event.CardID, match.BATTLEZONE)
-
-			if err != nil {
-				return
-			}
-
-			if !creature.HasFamily(family.Survivor) {
-				return
-			}
-
-			fx.SearchDeckTakeCards(
-				card,
-				ctx,
-				1,
-				func(x *match.Card) bool { return x.HasCondition(cnd.Survivor) },
-				"survivor",
-			)
-
-		}
-
-	})
+	}))
 
 }
 

--- a/game/cards/dm06/cyber_cluster.go
+++ b/game/cards/dm06/cyber_cluster.go
@@ -42,11 +42,8 @@ func ReceiveBlockerWhenOpponentPlaysCreatureOrSpell(card *match.Card, ctx *match
 		ReceiveBlockerWhenOpponentPlaysCard(card, ctx, event.MatchPlayerID)
 	}
 
-	if event, ok := ctx.Event.(*match.CardMoved); ok {
-		if event.To != match.BATTLEZONE {
-			return
-		}
-		ReceiveBlockerWhenOpponentPlaysCard(card, ctx, event.MatchPlayerID)
+	if fx.AnotherCreatureSummoned(card, ctx) {
+		ReceiveBlockerWhenOpponentPlaysCard(card, ctx, ctx.Event.(*match.CardMoved).MatchPlayerID)
 	}
 }
 

--- a/game/cards/dm06/cyber_cluster.go
+++ b/game/cards/dm06/cyber_cluster.go
@@ -43,7 +43,13 @@ func ReceiveBlockerWhenOpponentPlaysCreatureOrSpell(card *match.Card, ctx *match
 	}
 
 	if fx.AnotherCreatureSummoned(card, ctx) {
-		ReceiveBlockerWhenOpponentPlaysCard(card, ctx, ctx.Event.(*match.CardMoved).MatchPlayerID)
+		// This check can be removed once the card in CardMoved is passed as pointer
+		// And MatchPlayerID is removed
+		event, ok := ctx.Event.(*match.CardMoved)
+		if !ok {
+			return
+		}
+		ReceiveBlockerWhenOpponentPlaysCard(card, ctx, event.MatchPlayerID)
 	}
 }
 

--- a/game/cards/dm06/cyber_cluster.go
+++ b/game/cards/dm06/cyber_cluster.go
@@ -84,7 +84,7 @@ func FortMegacluster(c *match.Card) {
 	c.TapAbility = fortMegaclusterTapAbility
 
 	c.Use(fx.Creature, fx.Evolution, fx.TapAbility,
-		fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+		fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 			fx.GiveTapAbilityToAllies(
 				card,

--- a/game/cards/dm06/cyber_virus.go
+++ b/game/cards/dm06/cyber_virus.go
@@ -28,30 +28,13 @@ func RippleLotusQ(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Survivor, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Survivor, fx.When(fx.MySurvivorSummoned, func(card *match.Card, ctx *match.Context) {
 
-		if !ctx.Match.IsPlayerTurn(card.Player) || card.Zone != match.BATTLEZONE {
-			return
+		creatures := fx.Select(card.Player, ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Select 1 of your opponent's creature and tap it. Close to not tap any creatures.", 1, 1, true)
+		for _, creature := range creatures {
+			creature.Tapped = true
 		}
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
-
-			creature, err := card.Player.GetCard(event.CardID, match.BATTLEZONE)
-
-			if err != nil {
-				return
-			}
-
-			if creature.HasFamily(family.Survivor) && event.To == match.BATTLEZONE {
-				creatures := match.Search(card.Player, ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Select 1 of your opponent's creature and tap it. Close to not tap any creatures.", 1, 1, true)
-				for _, creature := range creatures {
-					creature.Tapped = true
-				}
-
-			}
-
-		}
-
-	})
+	}))
 
 }

--- a/game/cards/dm06/dragonoid.go
+++ b/game/cards/dm06/dragonoid.go
@@ -63,7 +63,7 @@ func LavaWalkerExecuto(c *match.Card) {
 	c.TapAbility = lavaWalkerExecutoTapAbility
 
 	c.Use(fx.Creature, fx.Evolution, fx.TapAbility,
-		fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+		fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 			fx.GiveTapAbilityToAllies(
 				card,

--- a/game/cards/dm06/ghost.go
+++ b/game/cards/dm06/ghost.go
@@ -18,7 +18,7 @@ func FrostSpecterShadowOfAge(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Evolution, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Evolution, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -35,9 +35,11 @@ func LuGilaSilverRiftGuardian(c *match.Card) {
 			return
 		}
 
-		if fx.AnotherCreatureSummoned(card, ctx) {
-
-			event, _ := ctx.Event.(*match.CardMoved)
+		// Can have a full refactoring to fx.When after CardMoved uses card pointer
+		if event, ok := ctx.Event.(*match.CardMoved); ok {
+			if event.To != match.BATTLEZONE || event.From == match.HIDDENZONE {
+				return
+			}
 
 			playedCard, err := ctx.Match.Player1.Player.GetCard(event.CardID, match.BATTLEZONE)
 			if err != nil {

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -17,28 +17,7 @@ func ForbosSanctumGuardianQ(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Survivor, func(card *match.Card, ctx *match.Context) {
-
-		if !ctx.Match.IsPlayerTurn(card.Player) || card.Zone != match.BATTLEZONE {
-			return
-		}
-
-		if event, ok := ctx.Event.(*match.CardMoved); ok && event.To == match.BATTLEZONE {
-
-			creature, err := card.Player.GetCard(event.CardID, match.BATTLEZONE)
-
-			if err != nil {
-				return
-			}
-
-			if !creature.HasFamily(family.Survivor) {
-				return
-			}
-
-			fx.SearchDeckTake1Spell(card, ctx)
-
-		}
-	})
+	c.Use(fx.Creature, fx.Survivor, fx.When(fx.MySurvivorSummoned, fx.SearchDeckTake1Spell))
 }
 
 func LuGilaSilverRiftGuardian(c *match.Card) {

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -98,7 +98,7 @@ func ArcBinetheAstounding(c *match.Card) {
 	c.TapAbility = arcBinetheAstoundingSpecialAbility
 
 	c.Use(fx.Creature, fx.Evolution, fx.TapAbility,
-		fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+		fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
 			fx.GiveTapAbilityToAllies(
 				card,

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -56,10 +56,9 @@ func LuGilaSilverRiftGuardian(c *match.Card) {
 			return
 		}
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
-			if event.To != match.BATTLEZONE {
-				return
-			}
+		if fx.AnotherCreatureSummoned(card, ctx) {
+
+			event, _ := ctx.Event.(*match.CardMoved)
 
 			playedCard, err := ctx.Match.Player1.Player.GetCard(event.CardID, match.BATTLEZONE)
 			if err != nil {

--- a/game/cards/dm06/human.go
+++ b/game/cards/dm06/human.go
@@ -18,28 +18,25 @@ func ArmoredDecimatorValkaizer(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.Evolution, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Evolution, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmISummoned(card, ctx) {
+		fx.SelectFilterSelectablesOnly(
+			card.Player,
+			ctx.Match,
+			ctx.Match.Opponent(card.Player),
+			match.BATTLEZONE,
+			"Armored Decimator Valkaizer: You may select 1 opponent's creature with 4000 or less power and destroy it.",
+			0,
+			1,
+			true,
+			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 4000 },
+		).Map(func(x *match.Card) {
 
-			fx.SelectFilterSelectablesOnly(
-				card.Player,
-				ctx.Match,
-				ctx.Match.Opponent(card.Player),
-				match.BATTLEZONE,
-				"Armored Decimator Valkaizer: You may select 1 opponent's creature with 4000 or less power and destroy it.",
-				0,
-				1,
-				true,
-				func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 4000 },
-			).Map(func(x *match.Card) {
+			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Armored Decimator Valkaizer", x.Name))
+		})
 
-				ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-				ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Armored Decimator Valkaizer", x.Name))
-			})
-
-		}
-	})
+	}))
 
 }
 

--- a/game/cards/dm06/initiate.go
+++ b/game/cards/dm06/initiate.go
@@ -18,25 +18,17 @@ func CrazeValkyrieTheDrastic(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CardMoved); ok {
+		creatures := match.Search(card.Player, ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Craze Valkyrie, the Drastic: Choose up to 2 of your opponent's creature and tap them. Close to not tap any creatures.", 1, 2, true)
 
-			if event.CardID == card.ID && event.To == match.BATTLEZONE {
+		for _, creature := range creatures {
+			creature.Tapped = true
 
-				creatures := match.Search(card.Player, ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Craze Valkyrie, the Drastic: Choose up to 2 of your opponent's creature and tap them. Close to not tap any creatures.", 1, 2, true)
-
-				for _, creature := range creatures {
-					creature.Tapped = true
-
-					ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was tapped by %s's %s", creature.Name, card.Player.Username(), card.Name))
-				}
-
-			}
-
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was tapped by %s's %s", creature.Name, card.Player.Username(), card.Name))
 		}
 
-	})
+	}))
 
 }
 

--- a/game/cards/dm06/rock_beast.go
+++ b/game/cards/dm06/rock_beast.go
@@ -17,7 +17,10 @@ func RumblesaurQ(c *match.Card) {
 	c.ManaRequirement = []string{civ.Fire}
 
 	c.Use(fx.Creature, fx.SpeedAttacker, fx.Survivor)
-	c.Use(fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	// Currently this implementation buffs this card. If the card is removed, the other creatures
+	// still have SpeedAttacker, which should not be the case. Requires reimplementation of SpeedAttacker
+	// as a condition, not as a removal of another condition.
+	c.Use(fx.When(fx.MySurvivorSummoned, func(card *match.Card, ctx *match.Context) {
 		fx.FindFilter(
 			card.Player,
 			match.BATTLEZONE,
@@ -26,22 +29,4 @@ func RumblesaurQ(c *match.Card) {
 			x.RemoveCondition(cnd.SummoningSickness)
 		})
 	}))
-
-	c.Use(func(card *match.Card, ctx *match.Context) {
-		if card.Zone != match.BATTLEZONE {
-			return
-		}
-
-		if event, ok := ctx.Event.(*match.CardMoved); ok && event.To == match.BATTLEZONE {
-
-			fx.FindFilter(
-				card.Player,
-				match.BATTLEZONE,
-				func(x *match.Card) bool { return x.HasCondition(cnd.Survivor) },
-			).Map(func(x *match.Card) {
-				x.RemoveCondition(cnd.SummoningSickness)
-			})
-
-		}
-	})
 }

--- a/game/cards/dm06/spells.go
+++ b/game/cards/dm06/spells.go
@@ -372,22 +372,7 @@ func FaerieLife(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Spell, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
-
-		if match.AmICasted(card, ctx) {
-
-			cards := card.Player.PeekDeck(1)
-
-			for _, toMove := range cards {
-
-				card.Player.MoveCard(toMove.ID, match.DECK, match.MANAZONE, card.ID)
-				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s put %s into the manazone from the top of their deck", card.Player.Username(), toMove.Name))
-
-			}
-
-		}
-
-	})
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, fx.Draw1ToMana))
 }
 
 func BondsOfJustice(c *match.Card) {

--- a/game/fx/draw.go
+++ b/game/fx/draw.go
@@ -44,31 +44,28 @@ func Draw5(card *match.Card, ctx *match.Context) {
 	draw(card, ctx, 5)
 }
 
-// DrawToMana draws 1 card and puts it in the players manazone
-func DrawToMana(card *match.Card, ctx *match.Context) {
+// Draw1ToMana draws 1 card and puts it in the players manazone
+func Draw1ToMana(card *match.Card, ctx *match.Context) {
 
-	if event, ok := ctx.Event.(*match.CardMoved); ok {
+	cards := card.Player.PeekDeck(1)
 
-		if event.CardID == card.ID && (event.To == match.BATTLEZONE || event.To == match.SPELLZONE) {
-
-			cards := card.Player.PeekDeck(1)
-
-			if len(cards) < 1 {
-				return
-			}
-
-			c, err := card.Player.MoveCard(cards[0].ID, match.DECK, match.MANAZONE, card.ID)
-
-			if err != nil {
-				return
-			}
-
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was added to %s's manazone from the top of their deck", c.Name, ctx.Match.PlayerRef(card.Player).Socket.User.Username))
-
-		}
-
+	if len(cards) < 1 {
+		return
 	}
 
+	c, err := card.Player.MoveCard(cards[0].ID, match.DECK, match.MANAZONE, card.ID)
+
+	if err != nil {
+		return
+	}
+
+	ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was added to %s's manazone from the top of their deck", c.Name, card.Player.Username()))
+
+}
+
+func Draw2ToMana(card *match.Card, ctx *match.Context) {
+	Draw1ToMana(card, ctx)
+	Draw1ToMana(card, ctx)
 }
 
 func MayDraw1(card *match.Card, ctx *match.Context) {

--- a/game/fx/draw.go
+++ b/game/fx/draw.go
@@ -5,43 +5,14 @@ import (
 	"fmt"
 )
 
-func draw(card *match.Card, ctx *match.Context, n int) {
-
-	if event, ok := ctx.Event.(*match.CardMoved); ok {
-
-		if event.CardID == card.ID && (event.To == match.BATTLEZONE || event.To == match.SPELLZONE) {
-
-			card.Player.DrawCards(n)
-
-		}
-
-	}
-
-}
-
-// Draw1 draws 1 card when the card is added to the battlezone or spellzone
+// Draw1 Convenience method with standard signature for drawing 1
 func Draw1(card *match.Card, ctx *match.Context) {
-	draw(card, ctx, 1)
+	card.Player.DrawCards(1)
 }
 
-// Draw2 draws 2 card when the card is added to the battlezone or spellzone
+// Draw2 Convenience method with standard signature for drawing 1
 func Draw2(card *match.Card, ctx *match.Context) {
-	draw(card, ctx, 2)
-}
-
-// Draw3 draws 3 card when the card is added to the battlezone or spellzone
-func Draw3(card *match.Card, ctx *match.Context) {
-	draw(card, ctx, 3)
-}
-
-// Draw4 draws 4 card when the card is added to the battlezone or spellzone
-func Draw4(card *match.Card, ctx *match.Context) {
-	draw(card, ctx, 4)
-}
-
-// Draw5 draws 5 card when the card is added to the battlezone or spellzone
-func Draw5(card *match.Card, ctx *match.Context) {
-	draw(card, ctx, 5)
+	card.Player.DrawCards(2)
 }
 
 // Draw1ToMana draws 1 card and puts it in the players manazone

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -333,7 +333,25 @@ func SelectBacksideFilter(p *match.Player, m *match.Match, containerOwner *match
 // hooks are shorthands for checking if the context matches a certain condition
 
 // Summoned returns true if the card was summoned
+//
+// Does not activate if the card was under an Evolution card and becomes visible again.
 func Summoned(card *match.Card, ctx *match.Context) bool {
+	if event, ok := ctx.Event.(*match.CardMoved); ok {
+
+		if event.CardID == card.ID && event.To == match.BATTLEZONE && event.From != match.HIDDENZONE {
+			return true
+		}
+
+	}
+
+	return false
+}
+
+// InTheBattlezone returns true if the card arrives in the battlezone.
+//
+// Similar to summon but activates also if the card was under an Evolution card and becomes visible again.
+// Used for cards that have continuous effects while in the battlezone.
+func InTheBattlezone(card *match.Card, ctx *match.Context) bool {
 	if event, ok := ctx.Event.(*match.CardMoved); ok {
 
 		if event.CardID == card.ID && event.To == match.BATTLEZONE {
@@ -464,6 +482,10 @@ func ShieldBroken(card *match.Card, ctx *match.Context) bool {
 
 }
 
+// AnotherCreatureSummoned returns true if another card was summoned
+//
+// Does not activate if this current card is summoned.
+// Does not activate if a card that was under an Evolution card becomes visible again.
 func AnotherCreatureSummoned(card *match.Card, ctx *match.Context) bool {
 	if card.Zone != match.BATTLEZONE {
 		return false
@@ -471,7 +493,7 @@ func AnotherCreatureSummoned(card *match.Card, ctx *match.Context) bool {
 
 	if event, ok := ctx.Event.(*match.CardMoved); ok {
 
-		if event.CardID != card.ID && event.To == match.BATTLEZONE {
+		if event.CardID != card.ID && event.To == match.BATTLEZONE && event.From != match.HIDDENZONE {
 			return true
 		}
 

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -337,7 +337,12 @@ func SelectBacksideFilter(p *match.Player, m *match.Match, containerOwner *match
 //
 // Does not activate if the card was under an Evolution card and becomes visible again.
 func Summoned(card *match.Card, ctx *match.Context) bool {
-	return CreatureSummoned(card, ctx) && ctx.Event.(*match.CardMoved).CardID == card.ID
+	event, ok := ctx.Event.(*match.CardMoved)
+	if !ok {
+		return false
+	}
+
+	return CreatureSummoned(card, ctx) && event.CardID == card.ID
 }
 
 // InTheBattlezone returns true if the card arrives in the battlezone.
@@ -503,7 +508,12 @@ func MySurvivorSummoned(card *match.Card, ctx *match.Context) bool {
 		return false
 	}
 
-	creature, err := card.Player.GetCard(ctx.Event.(*match.CardMoved).CardID, match.BATTLEZONE)
+	event, ok := ctx.Event.(*match.CardMoved)
+	if !ok {
+		return false
+	}
+
+	creature, err := card.Player.GetCard(event.CardID, match.BATTLEZONE)
 	if err != nil {
 		return false
 	}
@@ -519,7 +529,12 @@ func MySurvivorSummoned(card *match.Card, ctx *match.Context) bool {
 // Does not activate if this current card is summoned.
 // Does not activate if a card that was under an Evolution card becomes visible again.
 func AnotherCreatureSummoned(card *match.Card, ctx *match.Context) bool {
-	return CreatureSummoned(card, ctx) && ctx.Event.(*match.CardMoved).CardID != card.ID
+	event, ok := ctx.Event.(*match.CardMoved)
+	if !ok {
+		return false
+	}
+
+	return CreatureSummoned(card, ctx) && event.CardID != card.ID
 }
 
 func AnotherCreatureDestroyed(card *match.Card, ctx *match.Context) bool {

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -1,6 +1,7 @@
 package fx
 
 import (
+	"duel-masters/game/family"
 	"duel-masters/game/match"
 )
 
@@ -336,15 +337,7 @@ func SelectBacksideFilter(p *match.Player, m *match.Match, containerOwner *match
 //
 // Does not activate if the card was under an Evolution card and becomes visible again.
 func Summoned(card *match.Card, ctx *match.Context) bool {
-	if event, ok := ctx.Event.(*match.CardMoved); ok {
-
-		if event.CardID == card.ID && event.To == match.BATTLEZONE && event.From != match.HIDDENZONE {
-			return true
-		}
-
-	}
-
-	return false
+	return CreatureSummoned(card, ctx) && ctx.Event.(*match.CardMoved).CardID == card.ID
 }
 
 // InTheBattlezone returns true if the card arrives in the battlezone.
@@ -482,24 +475,51 @@ func ShieldBroken(card *match.Card, ctx *match.Context) bool {
 
 }
 
-// AnotherCreatureSummoned returns true if another card was summoned
+// CreatureSummoned returns true if a card was summoned
 //
-// Does not activate if this current card is summoned.
 // Does not activate if a card that was under an Evolution card becomes visible again.
-func AnotherCreatureSummoned(card *match.Card, ctx *match.Context) bool {
+func CreatureSummoned(card *match.Card, ctx *match.Context) bool {
 	if card.Zone != match.BATTLEZONE {
 		return false
 	}
 
 	if event, ok := ctx.Event.(*match.CardMoved); ok {
 
-		if event.CardID != card.ID && event.To == match.BATTLEZONE && event.From != match.HIDDENZONE {
+		if event.To == match.BATTLEZONE && event.From != match.HIDDENZONE {
 			return true
 		}
 
 	}
 
 	return false
+}
+
+// MySurvivorSummoned returns true if one of my survivors is summoned
+//
+// Does not activate if a card that was under an Evolution card becomes visible again.
+func MySurvivorSummoned(card *match.Card, ctx *match.Context) bool {
+
+	if !CreatureSummoned(card, ctx) {
+		return false
+	}
+
+	creature, err := card.Player.GetCard(ctx.Event.(*match.CardMoved).CardID, match.BATTLEZONE)
+	if err != nil {
+		return false
+	}
+
+	if !creature.HasFamily(family.Survivor) {
+		return false
+	}
+	return true
+}
+
+// AnotherCreatureSummoned returns true if another card was summoned
+//
+// Does not activate if this current card is summoned.
+// Does not activate if a card that was under an Evolution card becomes visible again.
+func AnotherCreatureSummoned(card *match.Card, ctx *match.Context) bool {
+	return CreatureSummoned(card, ctx) && ctx.Event.(*match.CardMoved).CardID != card.ID
 }
 
 func AnotherCreatureDestroyed(card *match.Card, ctx *match.Context) bool {

--- a/game/match/helpers.go
+++ b/game/match/helpers.go
@@ -277,22 +277,6 @@ func ContainerHas(p *Player, containerName string, filter func(*Card) bool) bool
 
 }
 
-// AmISummoned returns true or falsed based on if the card is played
-//
-// Deprecated: New cards should use `fx.When(fx.Summoned)`
-func AmISummoned(card *Card, ctx *Context) bool {
-
-	if event, ok := ctx.Event.(*CardMoved); ok {
-
-		if event.CardID == card.ID && event.To == BATTLEZONE {
-			return true
-		}
-
-	}
-
-	return false
-}
-
 // AmICasted returns true or false based on if the card is casted as a spell
 //
 // Deprecated: New cards should use `fx.When(fx.SpellCast)`


### PR DESCRIPTION
Dependent on https://github.com/sindreslungaard/duel-masters/pull/256

The issue was caused by the movement of the cards from the hiddenzone which is not a true movement in game terms. Was required to make cards like `Pangaea's Will` and `Pouch Shell` work properly. So that when they remove the top card, to no trigger summon effects but still trigger continuous effects of cards.

It needed refactoring in many places, but the changes are small. It mostly transitions various implementations to use the `fx.When`. Also I think if we get all the cards to use `fx.When` in the future we can better handle effects when multiple cards have an effect triggered at the same time by just modifying the implementation in this method. Maybe even a selectable effect queue at some point.

I split it into relevant commits so that it's a bit easier to review.