### PR TITLE
Fix Propeller Mutant discarding wrong card

### DIFF
--- a/game/cards/dm07/hedrian.go
+++ b/game/cards/dm07/hedrian.go
@@ -6,6 +6,8 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
+	"math/rand"
 )
 
 func BattleshipMutant(c *match.Card) {
@@ -39,6 +41,35 @@ func PropellerMutant(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.When(fx.Destroyed, fx.OpponentDiscardsRandomCard))
+	c.Use(fx.Creature, fx.When(fx.Destroyed, func(card *match.Card, ctx *match.Context) {
+
+		// Reimplementing here OpponentDiscardsRandomCard with a twist. Since the discard is activated when this creature is destroyed,
+		// if it is destoryed by a spell, witouht this, there is a chance you would discard that spell from the hand since we only
+		// move the card from hand after its effect was applied.
+		// The proper solution would be to use a spellzone for when spells are active. This is a work around.
+
+		event, ok := ctx.Event.(*match.CardMoved)
+		if !ok {
+			return
+		}
+
+		hand, err := ctx.Match.Opponent(card.Player).Container(match.HAND)
+		if err != nil || len(hand) < 1 {
+			return
+		}
+
+		randomcard := hand[rand.Intn(len(hand))]
+		for randomcard.ID == event.Source {
+			if len(hand) == 1 {
+				return
+			}
+			randomcard = hand[rand.Intn(len(hand))]
+		}
+
+		discardedCard, err := ctx.Match.Opponent(card.Player).MoveCard(randomcard.ID, match.HAND, match.GRAVEYARD, card.ID)
+		if err == nil {
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was discarded from %s's hand by %s", discardedCard.Name, discardedCard.Player.Username(), card.Name))
+		}
+	}))
 
 }

--- a/game/fx/creature.go
+++ b/game/fx/creature.go
@@ -590,7 +590,7 @@ func Creature(card *match.Card, ctx *match.Context) {
 		}
 
 		ctx.ScheduleAfter(func() {
-			card.Player.MoveCard(card.ID, match.BATTLEZONE, match.GRAVEYARD, card.ID)
+			card.Player.MoveCard(card.ID, match.BATTLEZONE, match.GRAVEYARD, event.Source.ID)
 		})
 	}
 


### PR DESCRIPTION
Fix for https://discord.com/channels/600129691336048681/1295928472807669790

If propeller mutant is destroyed by a spell there is currently a chance it discards that spell, even though that shouldn't be possible. Ideally we would use Spellzone to hold spells when they are applying their effect. This is a work around for the current situation.