### PR TITLE
Feature: User stats system with its own view

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -72,6 +72,7 @@ func (api *API) Start(port string) {
 	api.HandleFunc("POST /api/auth/reset-password", api.changePasswordHandler)
 	api.HandleFunc("GET /api/preferences", api.getPreferencesHandler)
 	api.HandleFunc("PUT /api/preferences", api.updatePreferencesHandler)
+	api.HandleFunc("GET /api/stats", api.getStatsHandler)
 	api.HandleFunc("GET /api/match/{id}", api.getMatchHandler)
 	api.HandleFunc("POST /api/match", api.createMatchHandler)
 	api.HandleFunc("GET /api/cards", api.getCardsHandler)

--- a/api/handler_get_stats.go
+++ b/api/handler_get_stats.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"duel-masters/db"
+	"net/http"
+)
+
+func (api *API) getStatsHandler(w http.ResponseWriter, r *http.Request) {
+	user, err := db.GetUserForToken(r.Header.Get("Authorization"))
+	if err != nil {
+		write(w, http.StatusUnauthorized, Json{"message": "Unauthorized"})
+		return
+	}
+
+	write(w, http.StatusOK, Json{
+		"games_lost":         user.GamesLost,
+		"games_won":          user.GamesWon,
+		"total_games_played": user.TotalGamesPlayed,
+		"win_rate":           int(user.WinRate),
+	})
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -20,6 +20,7 @@ func Migrate(conn *mongo.Database) {
 
 	migs := []migration{
 		{key: "23_07_2023_update_decks", fn: Update_Decks_23_07_2023},
+		{key: "update_user_stats", fn: UpdateUserStats},
 	}
 
 	for _, m := range migs {

--- a/db/migrations/update_user_stats.go
+++ b/db/migrations/update_user_stats.go
@@ -1,0 +1,96 @@
+package migrations
+
+import (
+	"context"
+	"log"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func UpdateUserStats(db *mongo.Database) {
+    log.Println("Starting UpdateUserStats migration")
+
+    ctx := context.Background()
+
+    userStats := make(map[string]*UserStat)
+
+    cur, err := db.Collection("duels").Find(ctx, bson.M{})
+    if err != nil {
+        log.Fatal("Failed to fetch duels:", err)
+    }
+    defer cur.Close(ctx)
+
+    for cur.Next(ctx) {
+        var duel Duel
+        if err := cur.Decode(&duel); err != nil {
+            log.Println("Failed to decode duel:", err)
+            continue
+        }
+
+        processPlayer(duel.P1, duel.Winner, userStats)
+        processPlayer(duel.P2, duel.Winner, userStats)
+    }
+
+    if err := cur.Err(); err != nil {
+        log.Fatal("Cursor error:", err)
+    }
+
+    for uid, stats := range userStats {
+        filter := bson.D{{Key: "uid", Value: uid}}
+        update := bson.D{
+            {Key: "$set", Value: bson.D{
+                {Key: "total_games_played", Value: stats.TotalGamesPlayed},
+                {Key: "games_won", Value: stats.GamesWon},
+                {Key: "games_lost", Value: stats.GamesLost},
+                {Key: "win_rate", Value: stats.WinRate},
+            }},
+        }
+
+        _, err := db.Collection("users").UpdateOne(ctx, filter, update)
+        if err != nil {
+            log.Println("Failed to update user", uid, ":", err)
+        } else {
+            log.Println("Updated user stats for", uid)
+        }
+    }
+
+    log.Println("UpdateUserStats migration completed")
+}
+
+
+type Duel struct {
+	UID    string `bson:"uid"`
+	P1     string `bson:"p1"`
+	P2     string `bson:"p2"`
+	Winner string `bson:"winner"`
+}
+
+type UserStat struct {
+	TotalGamesPlayed int
+	GamesWon         int
+	GamesLost        int
+	WinRate          float64
+}
+
+func processPlayer(uid string, winnerUID string, userStats map[string]*UserStat) {
+	if uid == "" {
+		return
+	}
+
+	stats, exists := userStats[uid]
+	if !exists {
+		stats = &UserStat{}
+		userStats[uid] = stats
+	}
+
+	stats.TotalGamesPlayed++
+
+	if uid == winnerUID {
+		stats.GamesWon++
+	} else {
+		stats.GamesLost++
+	}
+
+	stats.WinRate = (float64(stats.GamesWon) / float64(stats.TotalGamesPlayed)) * 100
+}

--- a/db/user_model.go
+++ b/db/user_model.go
@@ -7,16 +7,20 @@ type UserSession struct {
 }
 
 type User struct {
-	UID         string        `json:"uid"`
-	Permissions []string      `json:"permissions"`
-	Username    string        `json:"username"`
-	Password    string        `json:"-"`
-	Email       string        `json:"email"`
-	Color       string        `json:"color"`
-	Playmat     string        `json:"playmat"`
-	Sessions    []UserSession `json:"-"`
-	MutedUsers  []string      `json:"muted_users"`
-	Chatblocked bool          `json:"-" bson:"chat_blocked"`
+	UID              string        `json:"uid"`
+	Permissions      []string      `json:"permissions"`
+	Username         string        `json:"username"`
+	Password         string        `json:"-"`
+	Email            string        `json:"email"`
+	Color            string        `json:"color"`
+	Playmat          string        `json:"playmat"`
+	Sessions         []UserSession `json:"-"`
+	MutedUsers       []string      `json:"muted_users"`
+	Chatblocked      bool          `json:"-" bson:"chat_blocked"`
+	TotalGamesPlayed int           `json:"total_games_played" bson:"total_games_played"`
+	GamesWon         int           `json:"games_won" bson:"games_won"`
+	GamesLost        int           `json:"games_lost" bson:"games_lost"`
+	WinRate          float64       `json:"win_rate" bson:"win_rate"`
 }
 
 var Users = conn().Collection("users")

--- a/db/user_model.go
+++ b/db/user_model.go
@@ -17,9 +17,9 @@ type User struct {
 	Sessions         []UserSession `json:"-"`
 	MutedUsers       []string      `json:"muted_users"`
 	Chatblocked      bool          `json:"-" bson:"chat_blocked"`
-	TotalGamesPlayed int           `json:"total_games_played" bson:"total_games_played"`
-	GamesWon         int           `json:"games_won" bson:"games_won"`
 	GamesLost        int           `json:"games_lost" bson:"games_lost"`
+	GamesWon         int           `json:"games_won" bson:"games_won"`
+	TotalGamesPlayed int           `json:"total_games_played" bson:"total_games_played"`
 	WinRate          float64       `json:"win_rate" bson:"win_rate"`
 }
 

--- a/webapp/src/components/Header.vue
+++ b/webapp/src/components/Header.vue
@@ -5,6 +5,8 @@
       <ul>
         <li @click="$router.push('overview')" class="">Lobby</li>
         <li class="no-cursor">|</li>
+        <li @click="$router.push('stats')">Stats</li>
+        <li class="no-cursor">|</li>
         <li @click="$router.push('decks')">Decks</li>
         <li class="no-cursor">|</li>
         <li @click="$router.push('settings')">Settings</li>
@@ -102,14 +104,14 @@ export default {
     username: () => localStorage.getItem("username"),
     changelog() {
       return marked.parse(this.rawChangelog);
-    }
+    },
   },
   data() {
     return {
       changelogOpen: false,
       changelogLastClosed: 0,
       rawChangelog:
-        "Failed to load changelog.. Please refresh the site and try again"
+        "Failed to load changelog.. Please refresh the site and try again",
     };
   },
   created() {
@@ -117,7 +119,7 @@ export default {
       .get(
         "https://raw.githubusercontent.com/sindreslungaard/duel-masters/master/CHANGELOG.md"
       )
-      .then(res => {
+      .then((res) => {
         this.rawChangelog = res.data;
       });
   },
@@ -138,8 +140,8 @@ export default {
     closeChangelog() {
       this.changelogOpen = false;
       this.changelogLastClosed = Date.now();
-    }
-  }
+    },
+  },
 };
 </script>
 
@@ -335,7 +337,7 @@ a {
   right: 0;
   width: 400px;
   height: 500px;
-  background: #0A0A0D;
+  background: #0a0a0d;
   border-radius: 4px;
   text-align: left;
   cursor: default;
@@ -350,7 +352,7 @@ a {
   top: -3px;
   right: 10px;
   transform: rotate(45deg);
-  background: #0A0A0D;
+  background: #0a0a0d;
   position: absolute;
   z-index: 998;
 }

--- a/webapp/src/router.js
+++ b/webapp/src/router.js
@@ -1,8 +1,7 @@
 import { createRouter, createWebHistory } from "vue-router";
+import { getSettings } from "./helpers/settings";
 import { call } from "./remote";
 import { store } from "./store";
-import { getSettings } from "./helpers/settings";
-
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -11,49 +10,56 @@ const router = createRouter({
       path: "/",
       name: "index",
       component: () => import("./views/Login.vue"),
-      meta: { noauth: true }
+      meta: { noauth: true },
     },
 
     {
       path: "/login",
       name: "login",
       component: () => import("./views/Login.vue"),
-      meta: { noauth: true }
+      meta: { noauth: true },
     },
 
     {
       path: "/register",
       name: "register",
       component: () => import("./views/Register.vue"),
-      meta: { noauth: true }
+      meta: { noauth: true },
     },
 
     {
       path: "/recover-password",
       name: "recover_password",
       component: () => import("./views/RecoverPassword.vue"),
-      meta: { noauth: true }
+      meta: { noauth: true },
     },
 
     {
       path: "/recover-password/:code",
       name: "reset_password",
       component: () => import("./views/ResetPassword.vue"),
-      meta: { noauth: true }
+      meta: { noauth: true },
     },
 
     {
       path: "/logout",
       name: "logout",
       component: () => import("./views/Logout.vue"),
-      meta: { auth: true }
+      meta: { auth: true },
     },
 
     {
       path: "/overview",
       name: "overview",
       component: () => import("./views/Overview.vue"),
-      meta: { auth: true }
+      meta: { auth: true },
+    },
+
+    {
+      path: "/stats",
+      name: "stats",
+      component: () => import("./views/Stats.vue"),
+      meta: { auth: true },
     },
 
     {
@@ -61,51 +67,51 @@ const router = createRouter({
       name: "decks",
       component: () => {
         if (getSettings().legacyDeckBuilder) {
-          return import("./views/Decks.vue")
-        }  
-        return import("./views/DecksNew.vue")
+          return import("./views/Decks.vue");
+        }
+        return import("./views/DecksNew.vue");
       },
-      meta: { auth: true }
+      meta: { auth: true },
     },
 
     {
       path: "/deck/:uid",
       name: "deck",
-      component: () => import("./views/Deck.vue")
+      component: () => import("./views/Deck.vue"),
     },
 
     {
       path: "/settings",
       name: "settings",
       component: () => import("./views/Settings.vue"),
-      meta: { auth: true }
+      meta: { auth: true },
     },
 
     {
       path: "/duel/:id",
       name: "duel",
       component: () => import("./views/Match.vue"),
-      meta: { auth: true }
+      meta: { auth: true },
     },
 
     {
       path: "/duel/:id/:invite",
       name: "duel_invite",
       component: () => import("./views/Match.vue"),
-      meta: { auth: true }
-    }
-  ]
+      meta: { auth: true },
+    },
+  ],
 });
 
 router.beforeEach((to, from, next) => {
   call({
     path: `/preferences`,
-    method: "GET"
+    method: "GET",
   })
-    .then(res => {
+    .then((res) => {
       store.preferences = res.data;
     })
-    .catch(err => {
+    .catch((err) => {
       if (err && err.response && err.response.data) {
         console.error(err.response.data.error);
       } else {
@@ -119,11 +125,11 @@ router.beforeEach((to, from, next) => {
 
   const hasToken = localStorage.getItem("token") ? true : false;
 
-  if (to.matched.some(record => record.meta.auth) && !hasToken) {
+  if (to.matched.some((record) => record.meta.auth) && !hasToken) {
     return next("/login?redirect_to=" + encodeURIComponent(to.fullPath));
   }
 
-  if (to.matched.some(record => record.meta.noauth) && hasToken) {
+  if (to.matched.some((record) => record.meta.noauth) && hasToken) {
     return next("/overview");
   }
 

--- a/webapp/src/views/Stats.vue
+++ b/webapp/src/views/Stats.vue
@@ -1,0 +1,124 @@
+<template>
+  <div>
+    <Header></Header>
+
+    <div class="stats-row">
+      <div class="flex-1">
+        <h1>Your Game Statistics</h1>
+        <div class="area">
+          <div class="stat-item">
+            <span class="stat-label">Total Games Played:</span>
+            <span class="stat-value">{{ stats.total_games_played }}</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label">Games Won:</span>
+            <span class="stat-value">{{ stats.games_won }}</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label">Games Lost:</span>
+            <span class="stat-value">{{ stats.games_lost }}</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label">Win Rate:</span>
+            <span class="stat-value">{{ stats.win_rate }}%</span>
+          </div>
+          <div v-if="statsError" class="error-message">
+            {{ statsError }}
+          </div>
+        </div>
+      </div>
+
+      <div class="flex-1"></div>
+
+      <div class="flex-1"></div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Header from "../components/Header.vue";
+import { call } from "../remote";
+
+export default {
+  name: "Stats",
+  components: { Header },
+  data() {
+    return {
+      stats: {
+        total_games_played: 0,
+        games_won: 0,
+        games_lost: 0,
+        win_rate: 0,
+      },
+      statsError: "",
+    };
+  },
+  async mounted() {
+    try {
+      const res = await call({
+        path: `/stats`,
+        method: "GET",
+      });
+
+      this.stats = res.data;
+    } catch (e) {
+      console.error("Error fetching stats:", e);
+      this.statsError =
+        e.response?.data?.message ||
+        e.message ||
+        "Failed to fetch stats, please try again.";
+    }
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.stats-row {
+  margin: 0 10px;
+  display: flex;
+  margin-bottom: 50px;
+
+  .area {
+    background: url(/assets/images/overlay_30.png);
+    padding: 10px;
+    border-radius: 4px;
+    margin-top: 10px;
+    font-size: 14px;
+    height: calc(100% - 45px);
+  }
+
+  h1 {
+    font-weight: normal;
+    font-size: 16px;
+    margin: 0;
+  }
+
+  .stat-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 0;
+    border-bottom: 1px solid #555;
+
+    .stat-label {
+      font-weight: bold;
+    }
+
+    .stat-value {
+      font-size: 14px;
+    }
+  }
+
+  .error-message {
+    color: red;
+    margin-top: 10px;
+  }
+}
+
+.stats-row > div {
+  margin: 5px;
+}
+
+.flex-1 {
+  flex: 1 1 0px;
+}
+</style>


### PR DESCRIPTION
## Description
As some users have wished for this feature for quite some time, myself included (even though I am pretty new to Shobu), I thought that I might as well add it. And by chance, you have already been tracking duels for around a year, which makes migration of old stats available.

## Changes
- Added stats to the user model
- Added migration scripts for easy migration, built on the existing system
- Added an extra `GET` API endpoint for the stats
- Added an extra view for the stats, built into the header
- Some minor refactoring (can be reverted if desired)

## Testing
I've tested migration of old accounts, setting up new accounts, stats tracking after a match (>60s), and the stats view itself. I've also tested disconnections, which are tracked as a loss for the disconnected player and a win for the other player. In my testing, nothing broke and it shouldn't really, as it's built on top of the existing match tracking foundation. But just because it **"WoRkS oN mY mAcHiNe"** doesn't mean it will on your production server. Well, software development things we have to live with, right?

## Notes
It's my first contribution here, and I don't have that much Go experience, but I hope you like the code quality. Feedback is appreciated.