### PR TITLE
Refactored AttackConfirmed and blockers list initialization + admin messages QoL improvements

### DIFF
--- a/game/cards/dm01/armorloid.go
+++ b/game/cards/dm01/armorloid.go
@@ -5,6 +5,7 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 // ArmoredWalkerUrherion ...
@@ -44,7 +45,16 @@ func RothusTheTraveler(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		creatures := match.Search(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Rothus, the Traveler: Select 1 creature from your battlezone that will be sent to your graveyard", 1, 1, false)
+		creatures := fx.Select(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.BATTLEZONE,
+			fmt.Sprintf("%s: Select 1 creature from your battlezone that will be sent to your graveyard", card.Name),
+			1,
+			1,
+			false,
+		)
 
 		for _, creature := range creatures {
 			ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
@@ -53,7 +63,16 @@ func RothusTheTraveler(c *match.Card) {
 		ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action")
 		defer ctx.Match.EndWait(card.Player)
 
-		opponentCreatures := match.Search(ctx.Match.Opponent(card.Player), ctx.Match, ctx.Match.Opponent(card.Player), match.BATTLEZONE, "Rothus, the Traveler: Select 1 creature from your battlezone that will be sent to your graveyard", 1, 1, false)
+		opponentCreatures := fx.Select(
+			ctx.Match.Opponent(card.Player),
+			ctx.Match,
+			ctx.Match.Opponent(card.Player),
+			match.BATTLEZONE,
+			fmt.Sprintf("%s: Select 1 creature from your battlezone that will be sent to your graveyard", card.Name),
+			1,
+			1,
+			false,
+		)
 
 		for _, creature := range opponentCreatures {
 			ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)

--- a/game/cards/dm01/brain_jacker.go
+++ b/game/cards/dm01/brain_jacker.go
@@ -17,7 +17,7 @@ func BloodySquito(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.CantAttackCreatures, fx.Suicide)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.CantAttackCreatures, fx.Suicide)
 
 }
 
@@ -31,6 +31,6 @@ func DarkClown(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.CantAttackCreatures, fx.Suicide)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.CantAttackCreatures, fx.Suicide)
 
 }

--- a/game/cards/dm01/colony_beetle.go
+++ b/game/cards/dm01/colony_beetle.go
@@ -46,35 +46,24 @@ func StormShell(c *match.Card) {
 			return
 		}
 
-		ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action")
+		selectedCards := fx.Select(
+			opponent,
+			ctx.Match,
+			opponent,
+			match.BATTLEZONE,
+			fmt.Sprintf("%s: Select 1 card from your battlezone that will be sent to your manazone", card.Name),
+			1,
+			1,
+			false,
+		)
 
-		ctx.Match.NewAction(opponent, battlezone, 1, 1, "Storm Shell: Select 1 card from your battlezone that will be sent to your manazone", false)
+		movedCard, err := opponent.MoveCard(selectedCards[0].ID, match.BATTLEZONE, match.MANAZONE, card.ID)
 
-		defer func() {
-			ctx.Match.EndWait(card.Player)
-			ctx.Match.CloseAction(opponent)
-		}()
-
-		for {
-
-			action := <-opponent.Action
-
-			if len(action.Cards) != 1 || !match.AssertCardsIn(battlezone, action.Cards...) {
-				ctx.Match.ActionWarning(opponent, "Your selection of cards does not fulfill the requirements")
-				continue
-			}
-
-			movedCard, err := opponent.MoveCard(action.Cards[0], match.BATTLEZONE, match.MANAZONE, card.ID)
-
-			if err != nil {
-				break
-			}
-
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was moved from %s's battlezone to their manazone", movedCard.Name, opponent.Username()))
-
-			break
-
+		if err != nil {
+			return
 		}
+
+		ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was moved from %s's battlezone to their manazone", movedCard.Name, opponent.Username()))
 
 	}))
 

--- a/game/cards/dm01/colony_beetle.go
+++ b/game/cards/dm01/colony_beetle.go
@@ -90,6 +90,6 @@ func TowerShell(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.When(fx.Attacking, fx.CantBeBlockedByPowerUpTo4000))
+	c.Use(fx.Creature, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo4000))
 
 }

--- a/game/cards/dm01/colony_beetle.go
+++ b/game/cards/dm01/colony_beetle.go
@@ -79,6 +79,6 @@ func TowerShell(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo4000))
+	c.Use(fx.Creature, fx.CantBeBlockedByPowerUpTo4000)
 
 }

--- a/game/cards/dm01/cyber_lord.go
+++ b/game/cards/dm01/cyber_lord.go
@@ -19,7 +19,7 @@ func Tropico(c *match.Card) {
 
 	c.Use(func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.AttackPlayer); ok {
+		if event, ok := ctx.Event.(*match.BlockerSelectionStep); ok {
 
 			if event.CardID != card.ID {
 				return
@@ -36,29 +36,7 @@ func Tropico(c *match.Card) {
 			}
 
 			ctx.ScheduleAfter(func() {
-				event.Blockers = make([]*match.Card, 0)
-			})
-
-		}
-
-		if event, ok := ctx.Event.(*match.AttackCreature); ok {
-
-			if event.CardID != card.ID {
-				return
-			}
-
-			creatures, err := card.Player.Container(match.BATTLEZONE)
-
-			if err != nil {
-				return
-			}
-
-			if len(creatures) < 3 {
-				return
-			}
-
-			ctx.ScheduleAfter(func() {
-				event.Blockers = make([]*match.Card, 0)
+				*event.Blockers = make([]*match.Card, 0)
 			})
 
 		}

--- a/game/cards/dm01/cyber_lord.go
+++ b/game/cards/dm01/cyber_lord.go
@@ -21,8 +21,8 @@ func Tropico(c *match.Card) {
 
 		if event, ok := ctx.Event.(*match.SelectBlockers); ok {
 
-			if event.CardWhoAttacked != card ||
-				event.CardWhoAttacked.Zone != match.BATTLEZONE {
+			if event.Attacker != card ||
+				event.Attacker.Zone != match.BATTLEZONE {
 				return
 			}
 

--- a/game/cards/dm01/cyber_lord.go
+++ b/game/cards/dm01/cyber_lord.go
@@ -17,11 +17,12 @@ func Tropico(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.BlockerSelectionStep); ok {
+		if event, ok := ctx.Event.(*match.SelectBlockers); ok {
 
-			if event.CardID != card.ID {
+			if event.CardWhoAttacked != card ||
+				event.CardWhoAttacked.Zone != match.BATTLEZONE {
 				return
 			}
 
@@ -36,11 +37,11 @@ func Tropico(c *match.Card) {
 			}
 
 			ctx.ScheduleAfter(func() {
-				*event.Blockers = make([]*match.Card, 0)
+				event.Blockers = make([]*match.Card, 0)
 			})
 
 		}
 
-	}, fx.Creature)
+	})
 
 }

--- a/game/cards/dm01/cyber_virus.go
+++ b/game/cards/dm01/cyber_virus.go
@@ -45,6 +45,6 @@ func MarineFlower(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.CantAttackCreatures)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.CantAttackCreatures)
 
 }

--- a/game/cards/dm01/fish.go
+++ b/game/cards/dm01/fish.go
@@ -17,7 +17,7 @@ func HunterFish(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.CantAttackCreatures)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.CantAttackCreatures)
 
 }
 
@@ -31,7 +31,7 @@ func Seamine(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker)
+	c.Use(fx.Creature, fx.Blocker())
 
 }
 

--- a/game/cards/dm01/gel_fish.go
+++ b/game/cards/dm01/gel_fish.go
@@ -38,7 +38,7 @@ func PhantomFish(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.CantAttackCreatures)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.CantAttackCreatures)
 
 }
 
@@ -52,7 +52,7 @@ func RevolverFish(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.CantAttackCreatures)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.CantAttackCreatures)
 
 }
 

--- a/game/cards/dm01/ghost.go
+++ b/game/cards/dm01/ghost.go
@@ -17,7 +17,7 @@ func DarkRavenShadowOfGrief(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker)
+	c.Use(fx.Creature, fx.Blocker())
 
 }
 
@@ -45,7 +45,7 @@ func NightMasterShadowOfDecay(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker)
+	c.Use(fx.Creature, fx.Blocker())
 
 }
 

--- a/game/cards/dm01/guardian.go
+++ b/game/cards/dm01/guardian.go
@@ -17,7 +17,7 @@ func DiaNorkMoonlightGuardian(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 
 }
 
@@ -31,7 +31,7 @@ func GranGureSpaceGuardian(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 
 }
 
@@ -45,7 +45,7 @@ func LaUraGigaSkyGuardian(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 
 }
 
@@ -59,6 +59,6 @@ func SzubsKinTwilightGuardian(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 
 }

--- a/game/cards/dm01/horned_beast.go
+++ b/game/cards/dm01/horned_beast.go
@@ -31,7 +31,7 @@ func StampedingLonghorn(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.When(fx.Attacking, fx.CantBeBlockedByPowerUpTo3000))
+	c.Use(fx.Creature, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo3000))
 
 }
 

--- a/game/cards/dm01/horned_beast.go
+++ b/game/cards/dm01/horned_beast.go
@@ -31,7 +31,7 @@ func StampedingLonghorn(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo3000))
+	c.Use(fx.Creature, fx.CantBeBlockedByPowerUpTo3000)
 
 }
 

--- a/game/cards/dm01/initiate.go
+++ b/game/cards/dm01/initiate.go
@@ -78,12 +78,12 @@ func ToelVizierOfHope(c *match.Card) {
 
 		if _, ok := ctx.Event.(*match.EndOfTurnStep); ok {
 
-			if !card.Player.HasCard(match.BATTLEZONE, card.ID) {
+			if !card.Player.HasCard(match.BATTLEZONE, card.ID) ||
+				!ctx.Match.IsPlayerTurn(card.Player) {
 				return
 			}
 
-			if ctx.Match.IsPlayerTurn(card.Player) {
-
+			if fx.BinaryQuestion(card.Player, ctx.Match, fmt.Sprintf("Do you want to untap all your creatures in the battlezone? (%s's effect)", card.Name)) {
 				creatures, err := card.Player.Container(match.BATTLEZONE)
 
 				if err != nil {
@@ -103,7 +103,6 @@ func ToelVizierOfHope(c *match.Card) {
 				if madeChanges {
 					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s untapped all creatures in %s's battlezone", card.Name, card.Player.Username()))
 				}
-
 			}
 
 		}

--- a/game/cards/dm01/leaviathan.go
+++ b/game/cards/dm01/leaviathan.go
@@ -17,7 +17,7 @@ func KingCoral(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker)
+	c.Use(fx.Creature, fx.Blocker())
 
 }
 

--- a/game/cards/dm01/light_bringer.go
+++ b/game/cards/dm01/light_bringer.go
@@ -31,7 +31,7 @@ func IocantTheOracle(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 
 	c.PowerModifier = func(m *match.Match, attacking bool) int {
 

--- a/game/cards/dm01/living_dead.go
+++ b/game/cards/dm01/living_dead.go
@@ -59,7 +59,7 @@ func WanderingBraineater(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.CantAttackCreatures)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.CantAttackCreatures)
 
 }
 

--- a/game/cards/dm01/starlight_tree.go
+++ b/game/cards/dm01/starlight_tree.go
@@ -17,7 +17,7 @@ func EmeraldGrass(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 
 }
 
@@ -31,7 +31,7 @@ func RubyGrass(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.When(fx.EndOfMyTurnCreatureBZ, fx.MayUntapSelf))
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.When(fx.EndOfMyTurnCreatureBZ, fx.MayUntapSelf))
 
 }
 
@@ -45,6 +45,6 @@ func SenatineJadeTree(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 
 }

--- a/game/cards/dm02/armored_wyvern.go
+++ b/game/cards/dm02/armored_wyvern.go
@@ -6,6 +6,7 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 // MetalwingSkyterror ...
@@ -18,13 +19,13 @@ func MetalwingSkyterror(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),
 			match.BATTLEZONE,
-			"Metalwing Skyterror: You may destroy one of your opponent's blockers",
+			fmt.Sprintf("%s: You may destroy one of your opponent's blockers", card.Name),
 			1,
 			1,
 			true,
@@ -32,7 +33,6 @@ func MetalwingSkyterror(c *match.Card) {
 			false,
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			fx.RemoveBlockerFromList(x, ctx)
 		})
 	}))
 

--- a/game/cards/dm02/beast_folk.go
+++ b/game/cards/dm02/beast_folk.go
@@ -59,7 +59,7 @@ func SilverAxe(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(fx.MayDraw1ToMana))
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, fx.MayDraw1ToMana))
 
 }
 

--- a/game/cards/dm02/beast_folk.go
+++ b/game/cards/dm02/beast_folk.go
@@ -5,7 +5,6 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
-	"fmt"
 )
 
 // BarkwhipTheSmasher ...
@@ -60,23 +59,7 @@ func SilverAxe(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
-
-		cards := card.Player.PeekDeck(1)
-
-		if len(cards) < 1 {
-			return
-		}
-
-		c, err := card.Player.MoveCard(cards[0].ID, match.DECK, match.MANAZONE, card.ID)
-
-		if err != nil {
-			return
-		}
-
-		ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was added to %s's manazone from the top of their deck", c.Name, ctx.Match.PlayerRef(card.Player).Socket.User.Username))
-
-	}))
+	c.Use(fx.Creature, fx.WheneverThisAttacks(fx.MayDraw1ToMana))
 
 }
 

--- a/game/cards/dm02/brain_jacker.go
+++ b/game/cards/dm02/brain_jacker.go
@@ -19,28 +19,22 @@ func AmberPiercer(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
-		ctx.ScheduleAfter(func() {
-
-			fx.SelectFilterSelectablesOnly(
-				card.Player,
-				ctx.Match,
-				card.Player,
-				match.GRAVEYARD,
-				"Amber Piercer: Select a card to return from your graveyard to your hand.",
-				1,
-				1,
-				true,
-				func(x *match.Card) bool { return x.HasCondition(cnd.Creature) },
-			).Map(func(x *match.Card) {
-				if x.ID == card.ID {
-					return
-				}
-				card.Player.MoveCard(x.ID, match.GRAVEYARD, match.HAND, card.ID)
-				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was returned to %s's hand from their graveyard by Amber Piercer", x.Name, x.Player.Username()))
-			})
-
+		fx.SelectFilter(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.GRAVEYARD,
+			"You may select a creature to return from your graveyard to your hand.",
+			1,
+			1,
+			true,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Creature) },
+			false,
+		).Map(func(x *match.Card) {
+			card.Player.MoveCard(x.ID, match.GRAVEYARD, match.HAND, card.ID)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent to %s's hand from their graveyard by %s's effect", x.Name, card.Player.Username(), card.Name))
 		})
 
 	}))

--- a/game/cards/dm02/cyber_virus.go
+++ b/game/cards/dm02/cyber_virus.go
@@ -18,14 +18,14 @@ func StainedGlass(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
 		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),
 			match.BATTLEZONE,
-			"Stained Glass: Select 1 of your opponent's fire or nature creatures that will be returned to their hand",
+			fmt.Sprintf("%s: You may select 1 of your opponent's fire or nature creatures that will be returned to their hand", card.Name),
 			1,
 			1,
 			true,
@@ -33,8 +33,7 @@ func StainedGlass(c *match.Card) {
 			false,
 		).Map(func(x *match.Card) {
 			x.Player.MoveCard(x.ID, match.BATTLEZONE, match.HAND, card.ID)
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was sent to %s's hand from the battle zone by Stained Glass", x.Name, x.Player.Username()))
-			fx.RemoveBlockerFromList(x, ctx)
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was sent to %s's hand from the battle zone by %s's effect", x.Name, x.Player.Username(), card.Name))
 		})
 
 	}))

--- a/game/cards/dm02/demon_command.go
+++ b/game/cards/dm02/demon_command.go
@@ -17,6 +17,6 @@ func DarkTitanMaginn(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(fx.OpponentDiscardsRandomCard))
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, fx.OpponentDiscardsRandomCard))
 
 }

--- a/game/cards/dm02/demon_command.go
+++ b/game/cards/dm02/demon_command.go
@@ -17,6 +17,6 @@ func DarkTitanMaginn(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, fx.OpponentDiscardsRandomCard))
+	c.Use(fx.Creature, fx.WheneverThisAttacks(fx.OpponentDiscardsRandomCard))
 
 }

--- a/game/cards/dm02/gel_fish.go
+++ b/game/cards/dm02/gel_fish.go
@@ -31,7 +31,7 @@ func PlasmaChaser(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
 
 		toDraw := len(fx.Find(ctx.Match.Opponent(card.Player), match.BATTLEZONE))
 

--- a/game/cards/dm02/gel_fish.go
+++ b/game/cards/dm02/gel_fish.go
@@ -31,7 +31,7 @@ func PlasmaChaser(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
 		toDraw := len(fx.Find(ctx.Match.Opponent(card.Player), match.BATTLEZONE))
 

--- a/game/cards/dm02/ghost.go
+++ b/game/cards/dm02/ghost.go
@@ -17,6 +17,6 @@ func GrayBalloonShadowOfGreed(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 
 }

--- a/game/cards/dm02/giant_insect.go
+++ b/game/cards/dm02/giant_insect.go
@@ -17,6 +17,6 @@ func XenoMantis(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.Attacking, fx.CantBeBlockedByPowerUpTo5000))
+	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo5000))
 
 }

--- a/game/cards/dm02/giant_insect.go
+++ b/game/cards/dm02/giant_insect.go
@@ -17,6 +17,6 @@ func XenoMantis(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo5000))
+	c.Use(fx.Creature, fx.Doublebreaker, fx.CantBeBlockedByPowerUpTo5000)
 
 }

--- a/game/cards/dm02/guardian.go
+++ b/game/cards/dm02/guardian.go
@@ -35,16 +35,17 @@ func PhalEegaDawnGuardian(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilterSelectablesOnly(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
 			match.GRAVEYARD,
-			"Phal Eega, Dawn Guardian: Select a spell to return from your graveyard to your hand.",
+			fmt.Sprintf("%s: Select a spell to return from your graveyard to your hand.", card.Name),
 			1,
 			1,
 			true,
 			func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+			false,
 		).Map(func(x *match.Card) {
 			if x.ID == card.ID {
 				return

--- a/game/cards/dm02/guardian.go
+++ b/game/cards/dm02/guardian.go
@@ -19,7 +19,7 @@ func LadiaBaleTheInspirational(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.Evolution, fx.Doublebreaker)
+	c.Use(fx.Creature, fx.Blocker(), fx.Evolution, fx.Doublebreaker)
 
 }
 

--- a/game/cards/dm02/leviathan.go
+++ b/game/cards/dm02/leviathan.go
@@ -24,36 +24,30 @@ func KingNautilus(c *match.Card) {
 			return
 		}
 
-		if event, ok := ctx.Event.(*match.AttackCreature); ok {
-			kingNautilusSpecial(card, ctx, event.CardID)
-		}
-
-		if event, ok := ctx.Event.(*match.AttackPlayer); ok {
-			kingNautilusSpecial(card, ctx, event.CardID)
-		}
+		kingNautilusSpecial(card, ctx)
 
 	})
 
 }
 
-func kingNautilusSpecial(card *match.Card, ctx *match.Context, cardID string) {
+func kingNautilusSpecial(card *match.Card, ctx *match.Context) {
 
-	p := ctx.Match.CurrentPlayer()
+	if event, ok := ctx.Event.(*match.AttackConfirmed); ok {
 
-	creature, err := p.Player.GetCard(cardID, match.BATTLEZONE)
+		p := ctx.Match.CurrentPlayer()
 
-	if err != nil {
-		return
+		creature, err := p.Player.GetCard(event.CardID, match.BATTLEZONE)
+
+		if err != nil {
+			return
+		}
+
+		if !creature.HasFamily(family.LiquidPeople) {
+			return
+		}
+
+		creature.AddUniqueSourceCondition(cnd.CantBeBlocked, true, card.ID)
+
 	}
-
-	if !creature.HasFamily(family.LiquidPeople) {
-		return
-	}
-
-	creature.AddCondition(cnd.CantBeBlocked, true, card.ID)
-
-	ctx.ScheduleAfter(func() {
-		creature.RemoveConditionBySource(card.ID)
-	})
 
 }

--- a/game/cards/dm02/liquid_people.go
+++ b/game/cards/dm02/liquid_people.go
@@ -67,7 +67,7 @@ func AquaBouncer(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.When(fx.Summoned, fx.MayReturnCreatureToOwnersHand))
+	c.Use(fx.Creature, fx.Blocker(), fx.When(fx.Summoned, fx.MayReturnCreatureToOwnersHand))
 
 }
 
@@ -81,6 +81,6 @@ func AquaShooter(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker)
+	c.Use(fx.Creature, fx.Blocker())
 
 }

--- a/game/cards/dm02/liquid_people.go
+++ b/game/cards/dm02/liquid_people.go
@@ -41,7 +41,7 @@ func CrystalPaladin(c *match.Card) {
 			func(x *match.Card) bool { return x.HasCondition(cnd.Blocker) },
 		).Map(func(x *match.Card) {
 			x.Player.MoveCard(x.ID, match.BATTLEZONE, match.HAND, card.ID)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved from %s battle zone to their hand by Crystal Paladin", x.Name, x.Player.Username()))
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved from %s battle zone to their hand by %s", x.Name, x.Player.Username(), card.Name))
 		})
 
 		fx.FindFilter(
@@ -50,7 +50,7 @@ func CrystalPaladin(c *match.Card) {
 			func(x *match.Card) bool { return x.HasCondition(cnd.Blocker) },
 		).Map(func(x *match.Card) {
 			x.Player.MoveCard(x.ID, match.BATTLEZONE, match.HAND, card.ID)
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was moved from %s battle zone to their hand by Crystal Paladin", x.Name, x.Player.Username()))
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was moved from %s battle zone to their hand by %s", x.Name, x.Player.Username(), card.Name))
 		})
 
 	}))

--- a/game/cards/dm02/living_dead.go
+++ b/game/cards/dm02/living_dead.go
@@ -17,7 +17,7 @@ func MarrowOozeTheTwister(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker, fx.When(fx.AttackingPlayer, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Blocker(), fx.When(fx.AttackingPlayer, func(card *match.Card, ctx *match.Context) {
 
 		ctx.ScheduleAfter(func() {
 			ctx.Match.Destroy(card, card, match.DestroyedByMiscAbility)

--- a/game/cards/dm02/parasite_worm.go
+++ b/game/cards/dm02/parasite_worm.go
@@ -60,7 +60,7 @@ func HorridWorm(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, fx.OpponentDiscardsRandomCard))
+	c.Use(fx.Creature, fx.WheneverThisAttacks(fx.OpponentDiscardsRandomCard))
 
 }
 

--- a/game/cards/dm02/parasite_worm.go
+++ b/game/cards/dm02/parasite_worm.go
@@ -60,7 +60,7 @@ func HorridWorm(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(fx.OpponentDiscardsRandomCard))
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, fx.OpponentDiscardsRandomCard))
 
 }
 

--- a/game/cards/dm02/spells.go
+++ b/game/cards/dm02/spells.go
@@ -101,16 +101,17 @@ func CriticalBlade(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilterSelectablesOnly(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),
 			match.BATTLEZONE,
-			"Critical Blade: Select 1 of your opponent's blockers that will be destroyed",
+			fmt.Sprintf("%s: Select 1 of your opponent's blockers that will be destroyed", card.Name),
 			1,
 			1,
 			false,
 			func(x *match.Card) bool { return x.HasCondition(cnd.Blocker) },
+			false,
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedBySpell)
 		})

--- a/game/cards/dm02/starlight_tree.go
+++ b/game/cards/dm02/starlight_tree.go
@@ -17,7 +17,7 @@ func SpiralGrass(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Blocker(), func(card *match.Card, ctx *match.Context) {
 
 		if event, ok := ctx.Event.(*match.CreatureDestroyed); ok {
 

--- a/game/cards/dm03/armorloid.go
+++ b/game/cards/dm03/armorloid.go
@@ -18,43 +18,45 @@ func ArmoredWarriorQuelos(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
-		creatures := match.Filter(
+		creatures := fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
 			match.MANAZONE,
-			"Armored Warrior Quelos: Select 1 of your non-fire cards from mana zone and move it to graveyard.",
+			fmt.Sprintf("%s: Select 1 of your non-fire cards from mana zone and put it into your graveyard.", card.Name),
 			1,
 			1,
 			false,
 			func(x *match.Card) bool { return x.Civ != civ.Fire },
+			false,
 		)
 
 		for _, creature := range creatures {
 			card.Player.MoveCard(creature.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent to graveyard from %s's mana zone", creature.Name, card.Player.Username()))
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent to graveyard from %s's mana zone by %s's effect.", creature.Name, card.Player.Username(), card.Name))
 		}
 
 		ctx.Match.Wait(card.Player, "Waiting for your opponent to make an action")
 		defer ctx.Match.EndWait(card.Player)
 
-		opponentCreatures := match.Filter(
+		opponentCreatures := fx.SelectFilter(
 			ctx.Match.Opponent(card.Player),
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),
 			match.MANAZONE,
-			"Armored Warrior Quelos: Select 1 of your non-fire cards from mana zone and move it to graveyard.",
+			fmt.Sprintf("%s: Select 1 of your non-fire cards from mana zone and put it into your graveyard.", card.Name),
 			1,
 			1,
 			false,
 			func(x *match.Card) bool { return x.Civ != civ.Fire },
+			false,
 		)
 
 		for _, creature := range opponentCreatures {
 			ctx.Match.Opponent(card.Player).MoveCard(creature.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was sent to graveyard from %s's mana zone", creature.Name, ctx.Match.Opponent(card.Player).Username()))
+			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was sent to graveyard from %s's mana zone by %s's effect.", creature.Name, ctx.Match.Opponent(card.Player).Username(), card.Name))
 		}
 
 	}))

--- a/game/cards/dm03/balloon_mushroom.go
+++ b/game/cards/dm03/balloon_mushroom.go
@@ -18,14 +18,14 @@ func Psyshroom(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
 		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
 			match.GRAVEYARD,
-			fmt.Sprintf(card.Name, "(%s): You may choose a nature card from your graveyard to put into your mana zone"),
+			fmt.Sprintf("%s's effect: You may choose a nature card from your graveyard to put into your mana zone", card.Name),
 			0,
 			1,
 			true,
@@ -33,6 +33,7 @@ func Psyshroom(c *match.Card) {
 			false,
 		).Map(func(x *match.Card) {
 			card.Player.MoveCard(x.ID, match.GRAVEYARD, match.MANAZONE, card.ID)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent to %s's manazone from their graveyard by %s's effect.", x.Name, card.Player.Username(), card.Name))
 		})
 	}))
 

--- a/game/cards/dm03/balloon_mushroom.go
+++ b/game/cards/dm03/balloon_mushroom.go
@@ -5,6 +5,7 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 // Psyshroom ...
@@ -17,18 +18,19 @@ func Psyshroom(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilterSelectablesOnly(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
 			match.GRAVEYARD,
-			"Psyshroom: You may choose a nature card from your graveyard to put into your mana zone",
+			fmt.Sprintf(card.Name, "(%s): You may choose a nature card from your graveyard to put into your mana zone"),
 			0,
 			1,
 			true,
 			func(x *match.Card) bool { return x.Civ == civ.Nature },
+			false,
 		).Map(func(x *match.Card) {
 			card.Player.MoveCard(x.ID, match.GRAVEYARD, match.MANAZONE, card.ID)
 		})

--- a/game/cards/dm03/berserker.go
+++ b/game/cards/dm03/berserker.go
@@ -22,7 +22,7 @@ func AlekSolidityEnforcer(c *match.Card) {
 		return (getLightCardsInYourBattleZone(c) - 1) * 1000 //-1 to exclude self
 	}
 
-	c.Use(fx.Creature, fx.Blocker)
+	c.Use(fx.Creature, fx.Blocker())
 }
 
 // Return the number of water creatures in your battle zone

--- a/game/cards/dm03/cyber_cluster.go
+++ b/game/cards/dm03/cyber_cluster.go
@@ -26,7 +26,6 @@ func AnglerCluster(c *match.Card) {
 		return 3000
 	}
 
-
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackCreatures, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers)
 
 }

--- a/game/cards/dm03/demon_command.go
+++ b/game/cards/dm03/demon_command.go
@@ -33,7 +33,7 @@ func GamilKnightOfHatred(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
 		creatures := fx.SelectFilter(
 			card.Player,
@@ -50,7 +50,7 @@ func GamilKnightOfHatred(c *match.Card) {
 
 		for _, creature := range creatures {
 			card.Player.MoveCard(creature.ID, match.GRAVEYARD, match.HAND, card.ID)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand from their graveyard", creature.Name, card.Player.Username()))
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent to %s's hand from their graveyard by %s's effect", creature.Name, card.Player.Username(), card.Name))
 		}
 	}))
 

--- a/game/cards/dm03/demon_command.go
+++ b/game/cards/dm03/demon_command.go
@@ -33,16 +33,25 @@ func GamilKnightOfHatred(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
 
-		ctx.ScheduleAfter(func() {
-			creatures := match.Filter(card.Player, ctx.Match, card.Player, match.GRAVEYARD, "Select 1 of your darkness creatures from the graveyard that will be returned to your hand", 0, 1, true, func(x *match.Card) bool { return x.HasCondition(cnd.Creature) && x.Civ == civ.Darkness })
+		creatures := fx.SelectFilter(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.GRAVEYARD,
+			"Select 1 of your darkness creatures from your graveyard that will be returned to your hand",
+			0,
+			1,
+			true,
+			func(x *match.Card) bool { return x.HasCondition(cnd.Creature) && x.Civ == civ.Darkness },
+			false,
+		)
 
-			for _, creature := range creatures {
-				card.Player.MoveCard(creature.ID, match.GRAVEYARD, match.HAND, card.ID)
-				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand from their  graveyard", creature.Name, ctx.Match.PlayerRef(card.Player).Socket.User.Username))
-			}
-		})
+		for _, creature := range creatures {
+			card.Player.MoveCard(creature.ID, match.GRAVEYARD, match.HAND, card.ID)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to %s's hand from their graveyard", creature.Name, card.Player.Username()))
+		}
 	}))
 
 }

--- a/game/cards/dm03/giant.go
+++ b/game/cards/dm03/giant.go
@@ -19,7 +19,7 @@ func EarthstompGiant(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
 		manaZone, err := card.Player.Container(match.MANAZONE)
 
@@ -30,7 +30,7 @@ func EarthstompGiant(c *match.Card) {
 		for _, manaZoneCard := range manaZone {
 			if manaZoneCard.HasCondition(cnd.Creature) {
 				manaZoneCard.Player.MoveCard(manaZoneCard.ID, match.MANAZONE, match.HAND, card.ID)
-				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent from %s's manazone to their hand by %s", manaZoneCard.Name, manaZoneCard.Player.Username(), card.Name))
+				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent to %s's hand from manazone by %s's effect", manaZoneCard.Name, manaZoneCard.Player.Username(), card.Name))
 			}
 		}
 	}))

--- a/game/cards/dm03/giant.go
+++ b/game/cards/dm03/giant.go
@@ -19,7 +19,7 @@ func EarthstompGiant(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
 
 		manaZone, err := card.Player.Container(match.MANAZONE)
 

--- a/game/cards/dm03/giant_insect.go
+++ b/game/cards/dm03/giant_insect.go
@@ -63,7 +63,7 @@ func SniperMosquito(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
 
 		fx.Select(
 			card.Player,
@@ -75,7 +75,7 @@ func SniperMosquito(c *match.Card) {
 			1,
 			false,
 		).Map(func(x *match.Card) {
-			ctx.Match.MoveCard(x, match.HAND, card)
+			card.Player.MoveCard(x.ID, match.MANAZONE, match.HAND, card.ID)
 		})
 	}))
 }

--- a/game/cards/dm03/giant_insect.go
+++ b/game/cards/dm03/giant_insect.go
@@ -63,7 +63,7 @@ func SniperMosquito(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
 		fx.Select(
 			card.Player,
@@ -76,6 +76,7 @@ func SniperMosquito(c *match.Card) {
 			false,
 		).Map(func(x *match.Card) {
 			card.Player.MoveCard(x.ID, match.MANAZONE, match.HAND, card.ID)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent to %s's hand from their manazone hand by %s's effect", x.Name, card.Player.Username(), card.Name))
 		})
 	}))
 }

--- a/game/cards/dm03/guardian.go
+++ b/game/cards/dm03/guardian.go
@@ -17,5 +17,5 @@ func RazaVegaThunderGuardian(c *match.Card) {
 	c.ManaCost = 10
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.ReturnToShield)
+	c.Use(fx.Creature, fx.Blocker(), fx.ReturnToShield)
 }

--- a/game/cards/dm03/human.go
+++ b/game/cards/dm03/human.go
@@ -5,6 +5,7 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 // ExplosiveDudeJoe ...
@@ -31,14 +32,14 @@ func MuramasaDukeOfBlades(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
 		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),
 			match.BATTLEZONE,
-			"Muramasa, Duke of Blades: Select 1 of your opponent's creatures with power 2000 or less and destroy it",
+			fmt.Sprintf("%s: You may select 1 of your opponent's creatures with power 2000 or less and destroy it", card.Name),
 			1,
 			1,
 			true,
@@ -46,7 +47,6 @@ func MuramasaDukeOfBlades(c *match.Card) {
 			false,
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			fx.RemoveBlockerFromList(x, ctx)
 		})
 	}))
 

--- a/game/cards/dm03/initiate.go
+++ b/game/cards/dm03/initiate.go
@@ -64,7 +64,7 @@ func SiegBaliculaTheIntense(c *match.Card) {
 				match.BATTLEZONE,
 				func(x *match.Card) bool { return x.ID != card.ID && x.Civ == civ.Light },
 			).Map(func(x *match.Card) {
-				x.AddUniqueSourceCondition(cnd.Blocker, true, card.ID)
+				fx.ForceBlocker(x, ctx2, card.ID)
 			})
 
 		})

--- a/game/cards/dm03/leviathan.go
+++ b/game/cards/dm03/leviathan.go
@@ -19,7 +19,7 @@ func KingNeptas(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
 		cards := make(map[string][]*match.Card)
 
@@ -46,7 +46,7 @@ func KingNeptas(c *match.Card) {
 			c.Player,
 			ctx.Match,
 			cards,
-			"Choose up to 1 creatures in the battle zone and return it to its owner hand",
+			fmt.Sprintf("%s: Choose up to 1 creature in the battle zone and return it to its owner hand", card.Name),
 			0,
 			1,
 			true,
@@ -56,10 +56,9 @@ func KingNeptas(c *match.Card) {
 				return
 			}
 			ctx.Match.ReportActionInChat(x.Player, fmt.Sprintf("%s was moved to %s's hand", x.Name, x.Player.Username()))
-			fx.RemoveBlockerFromList(x, ctx)
 		})
 
-	}), fx.Creature)
+	}))
 
 }
 

--- a/game/cards/dm03/leviathan.go
+++ b/game/cards/dm03/leviathan.go
@@ -96,37 +96,34 @@ func LegendaryBynor(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, func(card *match.Card, ctx *match.Context) {
 
-		if card.Zone != match.BATTLEZONE {
+		if card.Zone != match.BATTLEZONE || !ctx.Match.IsPlayerTurn(card.Player) {
 			return
 		}
 
-		if event, ok := ctx.Event.(*match.AttackCreature); ok {
-			legendaryBynorSpecial(card, ctx, event.CardID)
-		}
-
-		if event, ok := ctx.Event.(*match.AttackPlayer); ok {
-			legendaryBynorSpecial(card, ctx, event.CardID)
-		}
+		legendaryBynorSpecial(card, ctx)
 
 	})
 
 }
 
-func legendaryBynorSpecial(card *match.Card, ctx *match.Context, cardID string) {
+func legendaryBynorSpecial(card *match.Card, ctx *match.Context) {
 
 	p := ctx.Match.CurrentPlayer()
 
-	creature, err := p.Player.GetCard(cardID, match.BATTLEZONE)
+	if event, ok := ctx.Event.(*match.AttackConfirmed); ok {
 
-	if err != nil {
-		return
+		creature, err := p.Player.GetCard(event.CardID, match.BATTLEZONE)
+
+		if err != nil {
+			return
+		}
+
+		if creature.Civ != civ.Water || creature.ID == card.ID {
+			return
+		}
+
+		creature.AddUniqueSourceCondition(cnd.CantBeBlocked, true, card.ID)
+
 	}
 
-	if creature.Civ != civ.Water || creature.ID == card.ID {
-		return
-	}
-
-	if ctx.Match.IsPlayerTurn(card.Player) {
-		creature.AddCondition(cnd.CantBeBlocked, true, card.ID)
-	}
 }

--- a/game/cards/dm03/starlight_tree.go
+++ b/game/cards/dm03/starlight_tree.go
@@ -20,17 +20,37 @@ func SparkleFlower(c *match.Card) {
 
 	// This card only checks for light cards at the untap step, when it should check every time your BZ get modified.
 	// TODO: minor bug - fix required
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	// TODO: see if it can be fixed with persistent effect
+	c.Use(fx.Creature,
 
-		if _, ok := ctx.Event.(*match.UntapStep); ok {
+		// if _, ok := ctx.Event.(*match.UntapStep); ok {
 
-			if match.ContainerHas(card.Player, match.MANAZONE, func(x *match.Card) bool { return x.Civ != civ.Light }) {
-				card.RemoveCondition(cnd.Blocker)
-			} else {
-				card.AddCondition(cnd.Blocker, true, card.ID)
-			}
-		}
+		// 	if match.ContainerHas(card.Player, match.MANAZONE, func(x *match.Card) bool { return x.Civ != civ.Light }) {
+		// 		card.RemoveCondition(cnd.Blocker)
+		// 	} else {
+		// 		card.AddCondition(cnd.Blocker, true, card.ID)
+		// 	}
+		// }
 
-	})
+		fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
+
+			ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
+
+				if card.Zone != match.BATTLEZONE {
+					card.RemoveConditionBySource(card.ID)
+
+					exit()
+					return
+				}
+
+				if match.ContainerHas(card.Player, match.MANAZONE, func(x *match.Card) bool { return x.Civ != civ.Light }) {
+					card.RemoveConditionBySource(card.ID)
+				} else {
+					card.AddUniqueSourceCondition(cnd.Blocker, true, card.ID)
+				}
+
+			})
+
+		}))
 
 }

--- a/game/cards/dm03/starlight_tree.go
+++ b/game/cards/dm03/starlight_tree.go
@@ -2,7 +2,6 @@ package dm03
 
 import (
 	"duel-masters/game/civ"
-	"duel-masters/game/cnd"
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
@@ -18,19 +17,7 @@ func SparkleFlower(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Light}
 
-	// This card only checks for light cards at the untap step, when it should check every time your BZ get modified.
-	// TODO: minor bug - fix required
-	// TODO: see if it can be fixed with persistent effect
 	c.Use(fx.Creature,
-
-		// if _, ok := ctx.Event.(*match.UntapStep); ok {
-
-		// 	if match.ContainerHas(card.Player, match.MANAZONE, func(x *match.Card) bool { return x.Civ != civ.Light }) {
-		// 		card.RemoveCondition(cnd.Blocker)
-		// 	} else {
-		// 		card.AddCondition(cnd.Blocker, true, card.ID)
-		// 	}
-		// }
 
 		fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 
@@ -46,7 +33,7 @@ func SparkleFlower(c *match.Card) {
 				if match.ContainerHas(card.Player, match.MANAZONE, func(x *match.Card) bool { return x.Civ != civ.Light }) {
 					card.RemoveConditionBySource(card.ID)
 				} else {
-					card.AddUniqueSourceCondition(cnd.Blocker, true, card.ID)
+					fx.ForceBlocker(card, ctx2, card.ID)
 				}
 
 			})

--- a/game/cards/dm03/tree_folk.go
+++ b/game/cards/dm03/tree_folk.go
@@ -22,7 +22,7 @@ func MaskedPomegranate(c *match.Card) {
 		return (getNatureCardsInYourBattleZone(c) - 1) * 1000 //-1 to exclude self
 	}
 
-	c.Use(fx.Creature, fx.When(fx.Attacking, fx.CantBeBlockedByPowerUpTo4000))
+	c.Use(fx.Creature, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo4000))
 
 }
 

--- a/game/cards/dm03/tree_folk.go
+++ b/game/cards/dm03/tree_folk.go
@@ -22,7 +22,7 @@ func MaskedPomegranate(c *match.Card) {
 		return (getNatureCardsInYourBattleZone(c) - 1) * 1000 //-1 to exclude self
 	}
 
-	c.Use(fx.Creature, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo4000))
+	c.Use(fx.Creature, fx.CantBeBlockedByPowerUpTo4000)
 
 }
 

--- a/game/cards/dm04/angel_command.go
+++ b/game/cards/dm04/angel_command.go
@@ -113,7 +113,7 @@ func AerisFlightElemental(c *match.Card) {
 			ctx.Match.Opponent(card.Player),
 			match.BATTLEZONE,
 			func(x *match.Card) bool {
-				return x.Civ == civ.Darkness && x.Tapped == false
+				return x.Civ == civ.Darkness && !x.Tapped
 			},
 		).Map(func(x *match.Card) {
 			// don't add if already in the list of attackable creatures

--- a/game/cards/dm04/armored_dragon.go
+++ b/game/cards/dm04/armored_dragon.go
@@ -5,7 +5,6 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
-	"fmt"
 )
 
 // GalklifeDragon ...
@@ -26,7 +25,6 @@ func GalklifeDragon(c *match.Card) {
 			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 4000 && x.Civ == civ.Light },
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by Galklife Dragon", x.Name))
 		})
 
 		fx.FindFilter(
@@ -35,7 +33,6 @@ func GalklifeDragon(c *match.Card) {
 			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 4000 && x.Civ == civ.Light },
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Galklife Dragon", x.Name))
 		})
 
 	}))

--- a/game/cards/dm04/berserker.go
+++ b/game/cards/dm04/berserker.go
@@ -18,7 +18,7 @@ func MilieusTheDaystretcher(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Blocker(), func(card *match.Card, ctx *match.Context) {
 
 		if card.Zone != match.BATTLEZONE {
 			return

--- a/game/cards/dm04/brain_jacker.go
+++ b/game/cards/dm04/brain_jacker.go
@@ -19,9 +19,7 @@ func PurplePiercer(c *match.Card) {
 
 	c.Use(
 		fx.Creature,
-		fx.CantBeBlockedIf(func(blocker *match.Card) bool {
-			return blocker.Civ == civ.Light
-		}),
+		fx.CantBeBlockedByLight,
 		fx.CantBeAttackedIf(func(attacker *match.Card) bool {
 			return attacker.Civ == civ.Light
 		}),

--- a/game/cards/dm04/cyber_cluster.go
+++ b/game/cards/dm04/cyber_cluster.go
@@ -17,7 +17,6 @@ func HunterCluster(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-
-	c.Use(fx.Creature, fx.Blocker, fx.ShieldTrigger)
+	c.Use(fx.Creature, fx.Blocker(), fx.ShieldTrigger)
 
 }

--- a/game/cards/dm04/dark_lord.go
+++ b/game/cards/dm04/dark_lord.go
@@ -29,7 +29,7 @@ func GregoriaPrincessOfWar(c *match.Card) {
 
 			demonCommands = append(demonCommands,
 				fx.FindFilter(
-					ctx.Match.Opponent(card.Player),
+					ctx2.Match.Opponent(card.Player),
 					match.BATTLEZONE,
 					func(x *match.Card) bool { return x.HasFamily(family.DemonCommand) },
 				)...,
@@ -46,7 +46,7 @@ func GregoriaPrincessOfWar(c *match.Card) {
 
 			demonCommands.Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.PowerAmplifier, 2000, card.ID)
-				x.AddUniqueSourceCondition(cnd.Blocker, true, card.ID)
+				fx.ForceBlocker(x, ctx2, card.ID)
 			})
 
 		})

--- a/game/cards/dm04/demon_command.go
+++ b/game/cards/dm04/demon_command.go
@@ -5,7 +5,6 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
-	"fmt"
 )
 
 // BallomMasterOfDeath ...
@@ -26,7 +25,6 @@ func BallomMasterOfDeath(c *match.Card) {
 			func(x *match.Card) bool { return x.Civ != civ.Darkness },
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by Ballom, Master of Death", x.Name))
 		})
 
 		fx.FindFilter(
@@ -35,7 +33,6 @@ func BallomMasterOfDeath(c *match.Card) {
 			func(x *match.Card) bool { return x.Civ != civ.Darkness },
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Ballom, Master of Death", x.Name))
 		})
 	}))
 

--- a/game/cards/dm04/demon_command.go
+++ b/game/cards/dm04/demon_command.go
@@ -84,7 +84,7 @@ func PhotocideLordOfTheWastes(c *match.Card) {
 			ctx.Match.Opponent(card.Player),
 			match.BATTLEZONE,
 			func(x *match.Card) bool {
-				return x.Civ == civ.Light && x.Tapped == false
+				return x.Civ == civ.Light && !x.Tapped
 			},
 		).Map(func(x *match.Card) {
 			// don't add if already in the list of attackable creatures

--- a/game/cards/dm04/ghost.go
+++ b/game/cards/dm04/ghost.go
@@ -25,7 +25,7 @@ func ShadowMoonCursedShade(c *match.Card) {
 			if card.Zone != match.BATTLEZONE {
 
 				// remove cards with current buffs
-				getDarknessCreatures(card, ctx).Map(func(x *match.Card) {
+				getDarknessCreatures(card, ctx2).Map(func(x *match.Card) {
 					x.RemoveConditionBySource(card.ID)
 				})
 
@@ -34,7 +34,7 @@ func ShadowMoonCursedShade(c *match.Card) {
 
 			}
 
-			getDarknessCreatures(card, ctx).Map(func(x *match.Card) {
+			getDarknessCreatures(card, ctx2).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.PowerAmplifier, 2000, card.ID)
 			})
 

--- a/game/cards/dm04/giant.go
+++ b/game/cards/dm04/giant.go
@@ -17,50 +17,5 @@ func AncientGiant(c *match.Card) {
 	c.ManaCost = 8
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(func(card *match.Card, ctx *match.Context) {
-
-		if event, ok := ctx.Event.(*match.AttackPlayer); ok {
-
-			if event.CardID != card.ID {
-				return
-			}
-
-			ctx.ScheduleAfter(func() {
-
-				blockers := make([]*match.Card, 0)
-
-				for _, blocker := range event.Blockers {
-					if blocker.Civ != civ.Darkness {
-						blockers = append(blockers, blocker)
-					}
-				}
-
-				event.Blockers = blockers
-
-			})
-
-		}
-
-		if event, ok := ctx.Event.(*match.AttackCreature); ok {
-
-			if event.CardID != card.ID {
-				return
-			}
-
-			ctx.ScheduleAfter(func() {
-
-				blockers := make([]*match.Card, 0)
-
-				for _, blocker := range event.Blockers {
-					if blocker.Civ != civ.Darkness {
-						blockers = append(blockers, blocker)
-					}
-				}
-
-				event.Blockers = blockers
-
-			})
-		}
-
-	}, fx.Creature, fx.Doublebreaker)
+	c.Use(fx.Creature, fx.Doublebreaker, fx.CantBeBlockedByDarkness)
 }

--- a/game/cards/dm04/giant_insect.go
+++ b/game/cards/dm04/giant_insect.go
@@ -30,7 +30,7 @@ func ThreeEyedDragonfly(c *match.Card) {
 			// reset this before each attack attempt
 			selectedCard = ""
 
-			cards := fx.SelectFilterSelectablesOnly(
+			cards := fx.SelectFilter(
 				card.Player,
 				ctx.Match,
 				card.Player,
@@ -40,6 +40,7 @@ func ThreeEyedDragonfly(c *match.Card) {
 				1,
 				true,
 				func(c *match.Card) bool { return c.ID != card.ID },
+				false,
 			)
 
 			if len(cards) > 0 {
@@ -49,7 +50,7 @@ func ThreeEyedDragonfly(c *match.Card) {
 			}
 		}),
 
-		fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
+		fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
 			if selectedCard == "" {
 				return
 			}

--- a/game/cards/dm04/giant_insect.go
+++ b/game/cards/dm04/giant_insect.go
@@ -20,7 +20,7 @@ func ThreeEyedDragonfly(c *match.Card) {
 	c.ManaRequirement = []string{civ.Nature}
 
 	// id of the card to destroy that the user selects when attacking
-	selectedCard := ""
+	selectedCardId := ""
 
 	c.Use(
 		fx.Creature,
@@ -28,14 +28,14 @@ func ThreeEyedDragonfly(c *match.Card) {
 		fx.When(fx.Attacking, func(card *match.Card, ctx *match.Context) {
 
 			// reset this before each attack attempt
-			selectedCard = ""
+			selectedCardId = ""
 
 			cards := fx.SelectFilter(
 				card.Player,
 				ctx.Match,
 				card.Player,
 				match.BATTLEZONE,
-				"Select one creature to destroy.",
+				"You may select one creature to destroy.",
 				0,
 				1,
 				true,
@@ -44,18 +44,18 @@ func ThreeEyedDragonfly(c *match.Card) {
 			)
 
 			if len(cards) > 0 {
-				selectedCard = cards[0].ID
+				selectedCardId = cards[0].ID
 				card.AddUniqueSourceCondition(cnd.DoubleBreaker, true, card.ID)
 				card.AddCondition(cnd.PowerAmplifier, 2000, card.ID)
 			}
 		}),
 
-		fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
-			if selectedCard == "" {
+		fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
+			if selectedCardId == "" {
 				return
 			}
 
-			x, err := card.Player.GetCard(selectedCard, match.BATTLEZONE)
+			x, err := card.Player.GetCard(selectedCardId, match.BATTLEZONE)
 
 			if err != nil {
 				card.RemoveConditionBySource(card.ID)
@@ -63,7 +63,7 @@ func ThreeEyedDragonfly(c *match.Card) {
 			}
 
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by Three-Eyed Dragonfly", x.Name))
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by %s's effect", x.Name, card.Name))
 		}),
 	)
 

--- a/game/cards/dm04/giant_insect.go
+++ b/game/cards/dm04/giant_insect.go
@@ -6,7 +6,6 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
-	"fmt"
 )
 
 // ThreeEyedDragonfly ...
@@ -63,7 +62,6 @@ func ThreeEyedDragonfly(c *match.Card) {
 			}
 
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by %s's effect", x.Name, card.Name))
 		}),
 	)
 

--- a/game/cards/dm04/giant_insect.go
+++ b/game/cards/dm04/giant_insect.go
@@ -28,6 +28,7 @@ func ThreeEyedDragonfly(c *match.Card) {
 
 			// reset this before each attack attempt
 			selectedCardId = ""
+			card.RemoveConditionBySource(card.ID)
 
 			cards := fx.SelectFilter(
 				card.Player,

--- a/game/cards/dm04/guardian.go
+++ b/game/cards/dm04/guardian.go
@@ -19,9 +19,7 @@ func GulanRiasSpeedGuardian(c *match.Card) {
 
 	c.Use(
 		fx.Creature,
-		fx.CantBeBlockedIf(func(blocker *match.Card) bool {
-			return blocker.Civ == civ.Darkness
-		}),
+		fx.CantBeBlockedByDarkness,
 		fx.CantBeAttackedIf(func(attacker *match.Card) bool {
 			return attacker.Civ == civ.Darkness
 		}),

--- a/game/cards/dm04/guardian.go
+++ b/game/cards/dm04/guardian.go
@@ -48,7 +48,7 @@ func MistRiasSonicGuardian(c *match.Card) {
 
 			if fx.AnotherCreatureSummoned(card, ctx2) {
 
-				fx.MayDraw1(card, ctx)
+				fx.MayDraw1(card, ctx2)
 
 			}
 

--- a/game/cards/dm04/hedrian.go
+++ b/game/cards/dm04/hedrian.go
@@ -43,7 +43,7 @@ func MongrelMan(c *match.Card) {
 
 			if fx.AnotherCreatureDestroyed(card, ctx2) {
 
-				fx.MayDraw1(card, ctx)
+				fx.MayDraw1(card, ctx2)
 
 			}
 

--- a/game/cards/dm04/initiate.go
+++ b/game/cards/dm04/initiate.go
@@ -31,6 +31,6 @@ func SariusVizierOfSuppression(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 
 }

--- a/game/cards/dm04/liquid_people.go
+++ b/game/cards/dm04/liquid_people.go
@@ -17,7 +17,7 @@ func AquaGuard(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackCreatures, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers)
 }
 
 // AquaJolter ...

--- a/game/cards/dm04/rock_beast.go
+++ b/game/cards/dm04/rock_beast.go
@@ -5,7 +5,6 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
-	"fmt"
 )
 
 // DoboulgyserGiantRockBeast ...
@@ -31,9 +30,7 @@ func DoboulgyserGiantRockBeast(c *match.Card) {
 			true,
 			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 3000 },
 		).Map(func(x *match.Card) {
-
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Doboulgyser", x.Name))
 		})
 
 	}))
@@ -58,7 +55,6 @@ func Magmarex(c *match.Card) {
 			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) == 1000 },
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed by Magmarex", x.Name))
 		})
 
 		fx.FindFilter(
@@ -67,7 +63,6 @@ func Magmarex(c *match.Card) {
 			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) == 1000 },
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Magmarex", x.Name))
 		})
 
 	}))

--- a/game/cards/dm04/spells.go
+++ b/game/cards/dm04/spells.go
@@ -269,9 +269,7 @@ func ChainsOfSacrifice(c *match.Card) {
 			1,
 			false,
 		).Map(func(x *match.Card) {
-
 			ctx.Match.Destroy(x, card, match.DestroyedBySpell)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s's %s has been destroyed.", x.Player.Username(), x.Name))
 		})
 
 		fx.Select(
@@ -284,9 +282,7 @@ func ChainsOfSacrifice(c *match.Card) {
 			2,
 			false,
 		).Map(func(x *match.Card) {
-
 			ctx.Match.Destroy(x, card, match.DestroyedBySpell)
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s's %s has been destroyed.", x.Player.Username(), x.Name))
 		})
 
 	}))

--- a/game/cards/dm04/spells.go
+++ b/game/cards/dm04/spells.go
@@ -16,30 +16,27 @@ func FullDefensor(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Spell, fx.ShieldTrigger, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmICasted(card, ctx) {
+		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 
-			ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
-				// on all events, add blocker to our creatures
-				fx.Find(
-					card.Player,
-					match.BATTLEZONE,
-				).Map(func(x *match.Card) {
-					x.AddUniqueSourceCondition(cnd.Blocker, true, card.ID)
-				})
-
-				// remove persistent effect on start of next turn
-				_, ok := ctx2.Event.(*match.StartOfTurnStep)
-				if ok && ctx2.Match.IsPlayerTurn(card.Player) {
-					exit()
-				}
-
+			// on all events, add blocker to our creatures
+			fx.Find(
+				card.Player,
+				match.BATTLEZONE,
+			).Map(func(x *match.Card) {
+				x.AddUniqueSourceCondition(cnd.Blocker, true, card.ID)
 			})
 
-		}
-	})
+			// remove persistent effect on start of next turn
+			_, ok := ctx2.Event.(*match.StartOfTurnStep)
+			if ok && ctx2.Match.IsPlayerTurn(card.Player) {
+				exit()
+			}
+
+		})
+
+	}))
 }
 
 // CloneFactory ...

--- a/game/cards/dm04/spells.go
+++ b/game/cards/dm04/spells.go
@@ -25,12 +25,19 @@ func FullDefensor(c *match.Card) {
 				card.Player,
 				match.BATTLEZONE,
 			).Map(func(x *match.Card) {
-				x.AddUniqueSourceCondition(cnd.Blocker, true, card.ID)
+				fx.ForceBlocker(x, ctx2, card.ID)
 			})
 
 			// remove persistent effect on start of next turn
 			_, ok := ctx2.Event.(*match.StartOfTurnStep)
 			if ok && ctx2.Match.IsPlayerTurn(card.Player) {
+				fx.Find(
+					card.Player,
+					match.BATTLEZONE,
+				).Map(func(x *match.Card) {
+					x.RemoveConditionBySource(card.ID)
+				})
+
 				exit()
 			}
 

--- a/game/cards/dm05/angel_command.go
+++ b/game/cards/dm05/angel_command.go
@@ -19,7 +19,7 @@ func SyriusFirmamentElemental(c *match.Card) {
 	c.ManaCost = 11
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.Triplebreaker)
+	c.Use(fx.Creature, fx.Blocker(), fx.Triplebreaker)
 
 }
 
@@ -33,7 +33,7 @@ func SyforceAuroraElemental(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Blocker(), fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
 		fx.SelectFilter(
 			card.Player,

--- a/game/cards/dm05/angel_command.go
+++ b/game/cards/dm05/angel_command.go
@@ -35,16 +35,17 @@ func SyforceAuroraElemental(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Blocker, fx.Doublebreaker, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilterSelectablesOnly(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
 			match.MANAZONE,
-			"You may select 1 spell from your mana zone that will be sent to your hand",
+			fmt.Sprintf("%s: You may select 1 spell from your mana zone that will be sent to your hand", card.Name),
 			1,
 			1,
 			true,
 			func(c *match.Card) bool { return c.HasCondition(cnd.Spell) },
+			false,
 		).Map(func(c *match.Card) {
 
 			c.Player.MoveCard(c.ID, match.MANAZONE, match.HAND, card.ID)

--- a/game/cards/dm05/gel_fish.go
+++ b/game/cards/dm05/gel_fish.go
@@ -19,7 +19,7 @@ func SeaSlug(c *match.Card) {
 	c.ManaCost = 8
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantBeBlocked)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantBeBlocked)
 
 }
 
@@ -70,6 +70,6 @@ func LurkingEel(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.FireAndNatureBlocker)
+	c.Use(fx.Creature, fx.FireAndNatureBlocker())
 
 }

--- a/game/cards/dm05/gel_fish.go
+++ b/game/cards/dm05/gel_fish.go
@@ -70,8 +70,6 @@ func LurkingEel(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.ConditionalBlocker(func(target *match.Card) bool {
-		return target.Civ == civ.Fire || target.Civ == civ.Nature
-	}))
+	c.Use(fx.Creature, fx.FireAndNatureBlocker)
 
 }

--- a/game/cards/dm05/giant_insect.go
+++ b/game/cards/dm05/giant_insect.go
@@ -19,9 +19,9 @@ func BloodwingMantis(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
 
-		fx.SelectFilterSelectablesOnly(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -31,6 +31,7 @@ func BloodwingMantis(c *match.Card) {
 			2,
 			false,
 			func(c *match.Card) bool { return c.HasCondition(cnd.Creature) },
+			false,
 		).Map(func(c *match.Card) {
 			c.Player.MoveCard(c.ID, match.MANAZONE, match.HAND, card.ID)
 			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was returned to %s's hand from manazone", c.Name, c.Player.Username()))

--- a/game/cards/dm05/giant_insect.go
+++ b/game/cards/dm05/giant_insect.go
@@ -19,7 +19,7 @@ func BloodwingMantis(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
 		fx.SelectFilter(
 			card.Player,
@@ -34,7 +34,7 @@ func BloodwingMantis(c *match.Card) {
 			false,
 		).Map(func(c *match.Card) {
 			c.Player.MoveCard(c.ID, match.MANAZONE, match.HAND, card.ID)
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was returned to %s's hand from manazone", c.Name, c.Player.Username()))
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was sent to %s's hand from their manazone by %s's effect", c.Name, c.Player.Username(), card.Name))
 		})
 
 	}))

--- a/game/cards/dm05/guardian.go
+++ b/game/cards/dm05/guardian.go
@@ -18,7 +18,7 @@ func SnorkLaShrineGuardian(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, func(card *match.Card, ctx *match.Context) {
 
 		if card.Zone != match.BATTLEZONE {
 			return

--- a/game/cards/dm05/guardian.go
+++ b/game/cards/dm05/guardian.go
@@ -69,7 +69,7 @@ func GalliaZohlIronGuardianQ(c *match.Card) {
 				match.BATTLEZONE,
 				func(x *match.Card) bool { return x.HasCondition(cnd.Survivor) },
 			).Map(func(x *match.Card) {
-				x.AddUniqueSourceCondition(cnd.Blocker, true, card.ID)
+				fx.ForceBlocker(x, ctx2, card.ID)
 			})
 
 		})

--- a/game/cards/dm05/initiate.go
+++ b/game/cards/dm05/initiate.go
@@ -17,52 +17,6 @@ func CalgoVizierOfRainclouds(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(func(card *match.Card, ctx *match.Context) {
-
-		if event, ok := ctx.Event.(*match.AttackPlayer); ok {
-
-			if event.CardID != card.ID {
-				return
-			}
-
-			ctx.ScheduleAfter(func() {
-
-				blockers := make([]*match.Card, 0)
-
-				for _, blocker := range event.Blockers {
-					if ctx.Match.GetPower(blocker, false) < 4000 {
-						blockers = append(blockers, blocker)
-					}
-				}
-
-				event.Blockers = blockers
-
-			})
-
-		}
-
-		if event, ok := ctx.Event.(*match.AttackCreature); ok {
-
-			if event.CardID != card.ID {
-				return
-			}
-
-			ctx.ScheduleAfter(func() {
-
-				blockers := make([]*match.Card, 0)
-
-				for _, blocker := range event.Blockers {
-					if ctx.Match.GetPower(blocker, false) < 4000 {
-						blockers = append(blockers, blocker)
-					}
-				}
-
-				event.Blockers = blockers
-
-			})
-
-		}
-
-	}, fx.Creature)
+	c.Use(fx.Creature, fx.CantBeBlockedByPower4000OrMore)
 
 }

--- a/game/cards/dm05/light_bringer.go
+++ b/game/cards/dm05/light_bringer.go
@@ -8,6 +8,7 @@ import (
 )
 
 func LeQuistTheOracle(c *match.Card) {
+
 	c.Name = "Le Quist, the Oracle"
 	c.Power = 1500
 	c.Civ = civ.Light

--- a/game/cards/dm05/mecha_thunder.go
+++ b/game/cards/dm05/mecha_thunder.go
@@ -31,7 +31,7 @@ func LaByleSeekerOfTheWinds(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Blocker(), func(card *match.Card, ctx *match.Context) {
 
 		if event, ok := ctx.Event.(*match.CreatureDestroyed); ok {
 

--- a/game/cards/dm05/spells.go
+++ b/game/cards/dm05/spells.go
@@ -130,57 +130,54 @@ func SlimeVeil(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Spell, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		if match.AmICasted(card, ctx) {
+		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 
-			ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
+			// remove persistent effect on start of next turn
+			if _, ok := ctx2.Event.(*match.StartOfTurnStep); ok && ctx2.Match.IsPlayerTurn(card.Player) {
+				exit()
+			}
 
-				// remove persistent effect on start of next turn
-				if _, ok := ctx2.Event.(*match.StartOfTurnStep); ok && ctx2.Match.IsPlayerTurn(card.Player) {
-					exit()
-				}
+			// on all events, add force attack to opponent's creatures
+			fx.Find(
+				ctx2.Match.Opponent(card.Player),
+				match.BATTLEZONE,
+			).Map(func(c *match.Card) {
 
-				// on all events, add force attack to opponent's creatures
-				fx.Find(
-					ctx2.Match.Opponent(card.Player),
-					match.BATTLEZONE,
-				).Map(func(c *match.Card) {
+				if _, ok := ctx2.Event.(*match.EndTurnEvent); ok && c.Zone == match.BATTLEZONE {
 
-					if _, ok := ctx2.Event.(*match.EndTurnEvent); ok && c.Zone == match.BATTLEZONE {
+					if ctx2.Match.IsPlayerTurn(c.Player) && !c.HasCondition(cnd.SummoningSickness) && !c.Tapped {
 
-						if ctx2.Match.IsPlayerTurn(c.Player) && !c.HasCondition(cnd.SummoningSickness) && !c.Tapped {
+						if c.HasCondition(cnd.CantAttackPlayers) {
 
-							if c.HasCondition(cnd.CantAttackPlayers) {
-
-								if c.HasCondition(cnd.CantAttackCreatures) {
-									return
-								}
-
-								attackableCreatures := fx.FindFilter(
-									ctx2.Match.Opponent(c.Player),
-									match.BATTLEZONE,
-									func(x *match.Card) bool { return x.Tapped || c.HasCondition(cnd.AttackUntapped) })
-
-								if len(attackableCreatures) == 0 {
-									return
-								}
-
+							if c.HasCondition(cnd.CantAttackCreatures) {
+								return
 							}
 
-							ctx2.Match.WarnPlayer(c.Player, fmt.Sprintf("%s must attack before you can end your turn", c.Name))
-							ctx2.InterruptFlow()
+							attackableCreatures := fx.FindFilter(
+								ctx2.Match.Opponent(c.Player),
+								match.BATTLEZONE,
+								func(x *match.Card) bool { return x.Tapped || c.HasCondition(cnd.AttackUntapped) })
+
+							if len(attackableCreatures) == 0 {
+								return
+							}
 
 						}
 
+						ctx2.Match.WarnPlayer(c.Player, fmt.Sprintf("%s must attack before you can end your turn", c.Name))
+						ctx2.InterruptFlow()
+
 					}
 
-				})
+				}
 
 			})
 
-		}
-	})
+		})
+
+	}))
 }
 
 // BrutalCharge ...

--- a/game/cards/dm05/spells.go
+++ b/game/cards/dm05/spells.go
@@ -137,6 +137,7 @@ func SlimeVeil(c *match.Card) {
 			// remove persistent effect on start of next turn
 			if _, ok := ctx2.Event.(*match.StartOfTurnStep); ok && ctx2.Match.IsPlayerTurn(card.Player) {
 				exit()
+				return
 			}
 
 			// on all events, add force attack to opponent's creatures

--- a/game/cards/dm06/angel_command.go
+++ b/game/cards/dm06/angel_command.go
@@ -18,29 +18,26 @@ func GarielElementalOfSunbeams(c *match.Card) {
 
 	spellcast := false
 
-	c.Use(fx.Creature, fx.Doublebreaker, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker,
+		fx.When(fx.IHaveCastASpell, func(card *match.Card, ctx *match.Context) { spellcast = true }),
+		func(card *match.Card, ctx *match.Context) {
 
-		if _, ok := ctx.Event.(*match.SpellCast); ok {
-			spellcast = true
-		}
-
-		// remove persistent effect when turn ends
-		_, ok := ctx.Event.(*match.EndStep)
-		if ok {
-			spellcast = false
-		}
-
-		if event, ok := ctx.Event.(*match.PlayCardEvent); ok {
-			if event.CardID == card.ID {
-				if !spellcast {
-					ctx.InterruptFlow()
-					ctx.Match.WarnPlayer(card.Player, "You can summon this creature only if you have cast a spell this round")
-					return
-				}
+			// reset spellcast flag at the end of the turn
+			if _, ok := ctx.Event.(*match.EndStep); ok {
+				spellcast = false
 			}
 
-		}
+			if event, ok := ctx.Event.(*match.PlayCardEvent); ok {
+				if event.CardID == card.ID {
+					if !spellcast {
+						ctx.InterruptFlow()
+						ctx.Match.WarnPlayer(card.Player, "You can summon this creature only if you have cast a spell this turn.")
+						return
+					}
+				}
 
-	})
+			}
+
+		})
 
 }

--- a/game/cards/dm06/brain_jacker.go
+++ b/game/cards/dm06/brain_jacker.go
@@ -16,6 +16,6 @@ func CursedPincher(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker, fx.Slayer, fx.CantAttackPlayers, fx.CantAttackCreatures)
+	c.Use(fx.Creature, fx.Blocker(), fx.Slayer, fx.CantAttackPlayers, fx.CantAttackCreatures)
 
 }

--- a/game/cards/dm06/chimera.go
+++ b/game/cards/dm06/chimera.go
@@ -16,7 +16,7 @@ func Gigagriff(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker, fx.Slayer, fx.CantAttackPlayers, fx.CantAttackCreatures)
+	c.Use(fx.Creature, fx.Blocker(), fx.Slayer, fx.CantAttackPlayers, fx.CantAttackCreatures)
 }
 
 func PhantasmalHorrorGigazald(c *match.Card) {

--- a/game/cards/dm06/cyber_cluster.go
+++ b/game/cards/dm06/cyber_cluster.go
@@ -113,5 +113,5 @@ func FortMegacluster(c *match.Card) {
 
 func fortMegaclusterTapAbility(card *match.Card, ctx *match.Context) {
 	card.Player.DrawCards(1)
-	ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s activated %s's tap ability to draw 1 cards", card.Player.Username(), card.Name))
+	ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s activated %s's tap ability to draw 1 card", card.Player.Username(), card.Name))
 }

--- a/game/cards/dm06/cyber_cluster.go
+++ b/game/cards/dm06/cyber_cluster.go
@@ -43,13 +43,12 @@ func ReceiveBlockerWhenOpponentPlaysCreatureOrSpell(card *match.Card, ctx *match
 	}
 
 	if fx.AnotherCreatureSummoned(card, ctx) {
-		// This check can be removed once the card in CardMoved is passed as pointer
+		// TODO: This check can be removed once the card in CardMoved is passed as pointer
 		// And MatchPlayerID is removed
-		event, ok := ctx.Event.(*match.CardMoved)
-		if !ok {
-			return
+		if event, ok := ctx.Event.(*match.CardMoved); ok {
+			ReceiveBlockerWhenOpponentPlaysCard(card, ctx, event.MatchPlayerID)
 		}
-		ReceiveBlockerWhenOpponentPlaysCard(card, ctx, event.MatchPlayerID)
+
 	}
 }
 

--- a/game/cards/dm06/cyber_cluster.go
+++ b/game/cards/dm06/cyber_cluster.go
@@ -2,7 +2,6 @@ package dm06
 
 import (
 	"duel-masters/game/civ"
-	"duel-masters/game/cnd"
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
@@ -34,28 +33,46 @@ func OverloadCluster(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, ReceiveBlockerWhenOpponentPlaysCreatureOrSpell)
+	isBlocker := false
+
+	c.Use(fx.Creature,
+		fx.When(ReceiveBlockerWhenOpponentPlaysCreatureOrSpell,
+			func(c *match.Card, ctx *match.Context) { isBlocker = true }),
+		fx.When(fx.EndOfTurn,
+			func(c *match.Card, ctx *match.Context) {
+				isBlocker = false
+				c.RemoveConditionBySource(c.ID)
+			}),
+		fx.When(func(c *match.Card, ctx *match.Context) bool { return isBlocker },
+			func(c *match.Card, ctx *match.Context) {
+				fx.ForceBlocker(c, ctx, c.ID)
+			}),
+	)
 }
 
-func ReceiveBlockerWhenOpponentPlaysCreatureOrSpell(card *match.Card, ctx *match.Context) {
+func ReceiveBlockerWhenOpponentPlaysCreatureOrSpell(card *match.Card, ctx *match.Context) bool {
+
 	if event, ok := ctx.Event.(*match.SpellCast); ok {
-		ReceiveBlockerWhenOpponentPlaysCard(card, ctx, event.MatchPlayerID)
+		return shouldReceiveBlockerWhenOpponentPlaysCard(card, ctx, event.MatchPlayerID)
 	}
 
 	if fx.AnotherCreatureSummoned(card, ctx) {
 		// TODO: This check can be removed once the card in CardMoved is passed as pointer
 		// And MatchPlayerID is removed
 		if event, ok := ctx.Event.(*match.CardMoved); ok {
-			ReceiveBlockerWhenOpponentPlaysCard(card, ctx, event.MatchPlayerID)
+			return shouldReceiveBlockerWhenOpponentPlaysCard(card, ctx, event.MatchPlayerID)
 		}
 
 	}
+
+	return false
+
 }
 
-func ReceiveBlockerWhenOpponentPlaysCard(card *match.Card, ctx *match.Context, playedCardPlayerId byte) {
+func shouldReceiveBlockerWhenOpponentPlaysCard(card *match.Card, ctx *match.Context, playedCardPlayerId byte) bool {
 
 	if card.Zone != match.BATTLEZONE || playedCardPlayerId == 0 {
-		return
+		return false
 	}
 
 	// Return if it's not the opponent that plays the card
@@ -65,13 +82,8 @@ func ReceiveBlockerWhenOpponentPlaysCard(card *match.Card, ctx *match.Context, p
 	} else {
 		playedCardPlayer = ctx.Match.Player2.Player
 	}
-	if card.Player == playedCardPlayer {
-		return
-	}
 
-	ctx.ScheduleAfter(func() {
-		card.AddCondition(cnd.Blocker, nil, card.ID)
-	})
+	return card.Player != playedCardPlayer
 
 }
 

--- a/game/cards/dm06/demon_command.go
+++ b/game/cards/dm06/demon_command.go
@@ -17,7 +17,7 @@ func ZorvazTheBonecrusher(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackCreatures, fx.CantAttackPlayers, fx.Suicide)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers, fx.Suicide)
 }
 
 func VileMulderWingOfTheVoid(c *match.Card) {

--- a/game/cards/dm06/demon_command.go
+++ b/game/cards/dm06/demon_command.go
@@ -5,6 +5,7 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 func ZorvazTheBonecrusher(c *match.Card) {
@@ -40,9 +41,18 @@ func DaidalosGeneralOfFury(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 
-		creatures := fx.Select(card.Player, ctx.Match, card.Player, match.BATTLEZONE, "Daidalos, General Of Fury: Select 1 creature from your battlezone that will be sent to your graveyard", 1, 1, false)
+		creatures := fx.Select(
+			card.Player,
+			ctx.Match,
+			card.Player,
+			match.BATTLEZONE,
+			fmt.Sprintf("%s: Select 1 creature from your battlezone that will be sent to your graveyard", card.Name),
+			1,
+			1,
+			false,
+		)
 
 		for _, creature := range creatures {
 			ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)

--- a/game/cards/dm06/dragonoid.go
+++ b/game/cards/dm06/dragonoid.go
@@ -78,7 +78,7 @@ func LavaWalkerExecuto(c *match.Card) {
 }
 
 func lavaWalkerExecutoTapAbility(card *match.Card, ctx *match.Context) {
-	creatures := fx.SelectFilterSelectablesOnly(
+	creatures := fx.SelectFilter(
 		card.Player,
 		ctx.Match,
 		card.Player,
@@ -88,6 +88,7 @@ func lavaWalkerExecutoTapAbility(card *match.Card, ctx *match.Context) {
 		1,
 		false,
 		func(x *match.Card) bool { return x.Civ == civ.Fire },
+		false,
 	)
 	for _, creature := range creatures {
 		creature.AddCondition(cnd.PowerAmplifier, 3000, card.ID)

--- a/game/cards/dm06/earth_eater.go
+++ b/game/cards/dm06/earth_eater.go
@@ -16,7 +16,7 @@ func HazardCrawler(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackCreatures, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers)
 }
 
 func MidnightCrawler(c *match.Card) {
@@ -40,5 +40,5 @@ func ThrashCrawler(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackCreatures, fx.CantAttackPlayers, fx.When(fx.Summoned, fx.ReturnMyCardFromMZToHand))
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers, fx.When(fx.Summoned, fx.ReturnMyCardFromMZToHand))
 }

--- a/game/cards/dm06/gel_fish.go
+++ b/game/cards/dm06/gel_fish.go
@@ -43,5 +43,5 @@ func MadrillonFish(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackCreatures, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers)
 }

--- a/game/cards/dm06/ghost.go
+++ b/game/cards/dm06/ghost.go
@@ -25,7 +25,7 @@ func FrostSpecterShadowOfAge(c *match.Card) {
 			if card.Zone != match.BATTLEZONE {
 
 				// remove cards with current buffs
-				getGhostCreatures(card, ctx).Map(func(x *match.Card) {
+				getGhostCreatures(card).Map(func(x *match.Card) {
 					x.RemoveConditionBySource(card.ID)
 				})
 
@@ -34,7 +34,7 @@ func FrostSpecterShadowOfAge(c *match.Card) {
 
 			}
 
-			getGhostCreatures(card, ctx).Map(func(x *match.Card) {
+			getGhostCreatures(card).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.Slayer, true, card.ID)
 			})
 
@@ -44,7 +44,7 @@ func FrostSpecterShadowOfAge(c *match.Card) {
 
 }
 
-func getGhostCreatures(card *match.Card, ctx *match.Context) fx.CardCollection {
+func getGhostCreatures(card *match.Card) fx.CardCollection {
 
 	ghostCreatures := fx.FindFilter(
 		card.Player,

--- a/game/cards/dm06/giant_insect.go
+++ b/game/cards/dm06/giant_insect.go
@@ -16,7 +16,7 @@ func UltraMantisScourgeOfFate(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo8000))
+	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.CantBeBlockedByPowerUpTo8000)
 
 }
 func SplinterclawWasp(c *match.Card) {

--- a/game/cards/dm06/giant_insect.go
+++ b/game/cards/dm06/giant_insect.go
@@ -16,7 +16,7 @@ func UltraMantisScourgeOfFate(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.Attacking, fx.CantBeBlockedByPowerUpTo8000))
+	c.Use(fx.Creature, fx.Evolution, fx.Doublebreaker, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo8000))
 
 }
 func SplinterclawWasp(c *match.Card) {

--- a/game/cards/dm06/gladiator.go
+++ b/game/cards/dm06/gladiator.go
@@ -17,7 +17,7 @@ func KanesillTheExplorer(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 }
 
 func TelitolTheExplorer(c *match.Card) {
@@ -29,7 +29,7 @@ func TelitolTheExplorer(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.When(fx.Summoned, func(card *match.Card, ctx *match.Context) {
 
 		shields, err := card.Player.Container(match.SHIELDZONE)
 

--- a/game/cards/dm06/gladiator.go
+++ b/game/cards/dm06/gladiator.go
@@ -5,6 +5,7 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 func KanesillTheExplorer(c *match.Card) {
@@ -44,7 +45,7 @@ func TelitolTheExplorer(c *match.Card) {
 
 		ctx.Match.ShowCards(
 			card.Player,
-			"Your shields:",
+			fmt.Sprintf("%s's effect: your shields:", card.Name),
 			ids,
 		)
 	}))

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -35,7 +35,7 @@ func LuGilaSilverRiftGuardian(c *match.Card) {
 			return
 		}
 
-		// Can have a full refactoring to fx.When after CardMoved uses card pointer
+		// TODO: Can have a full refactoring to fx.When after CardMoved uses card pointer
 		if event, ok := ctx.Event.(*match.CardMoved); ok {
 			if event.To != match.BATTLEZONE || event.From == match.HIDDENZONE {
 				return

--- a/game/cards/dm06/guardian.go
+++ b/game/cards/dm06/guardian.go
@@ -29,7 +29,7 @@ func LuGilaSilverRiftGuardian(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, func(card *match.Card, ctx *match.Context) {
 
 		if card.Zone != match.BATTLEZONE && card.Zone != match.HIDDENZONE {
 			return

--- a/game/cards/dm06/hedrian.go
+++ b/game/cards/dm06/hedrian.go
@@ -6,6 +6,7 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 func TankMutant(c *match.Card) {
@@ -26,7 +27,7 @@ func TankMutant(c *match.Card) {
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),
 			match.BATTLEZONE,
-			"Tank Mutant: Select 1 creature from your battlezone that will be sent to your graveyard",
+			fmt.Sprintf("%s: Select 1 creature from your battlezone that will be sent to your graveyard", card.Name),
 			1,
 			1,
 			false,

--- a/game/cards/dm06/human.go
+++ b/game/cards/dm06/human.go
@@ -31,9 +31,7 @@ func ArmoredDecimatorValkaizer(c *match.Card) {
 			true,
 			func(x *match.Card) bool { return ctx.Match.GetPower(x, false) <= 4000 },
 		).Map(func(x *match.Card) {
-
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
-			ctx.Match.ReportActionInChat(ctx.Match.Opponent(card.Player), fmt.Sprintf("%s was destroyed by Armored Decimator Valkaizer", x.Name))
 		})
 
 	}))

--- a/game/cards/dm06/initiate.go
+++ b/game/cards/dm06/initiate.go
@@ -53,7 +53,7 @@ func ChekiculVizierOfEndurance(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackCreatures, fx.CantAttackPlayers, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers, func(card *match.Card, ctx *match.Context) {
 
 		if event, ok := ctx.Event.(*match.Battle); ok {
 			if !event.Blocked || event.Defender != card {

--- a/game/cards/dm06/leviathan.go
+++ b/game/cards/dm06/leviathan.go
@@ -16,5 +16,19 @@ func KingTriumphant(c *match.Card) {
 	c.ManaCost = 8
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Doublebreaker, ReceiveBlockerWhenOpponentPlaysCreatureOrSpell)
+	isBlocker := false
+
+	c.Use(fx.Creature, fx.Doublebreaker,
+		fx.When(ReceiveBlockerWhenOpponentPlaysCreatureOrSpell,
+			func(c *match.Card, ctx *match.Context) { isBlocker = true }),
+		fx.When(fx.EndOfTurn,
+			func(c *match.Card, ctx *match.Context) {
+				isBlocker = false
+				c.RemoveConditionBySource(c.ID)
+			}),
+		fx.When(func(c *match.Card, ctx *match.Context) bool { return isBlocker },
+			func(c *match.Card, ctx *match.Context) {
+				fx.ForceBlocker(c, ctx, c.ID)
+			}),
+	)
 }

--- a/game/cards/dm06/light_bringer.go
+++ b/game/cards/dm06/light_bringer.go
@@ -45,7 +45,7 @@ func YulukTheOracle(c *match.Card) {
 			if event.CardID == card.ID {
 				if !spellcast {
 					ctx.InterruptFlow()
-					ctx.Match.WarnPlayer(card.Player, "You can summon this creature only if you have cast a spell this round")
+					ctx.Match.WarnPlayer(card.Player, "You can summon this creature only if you have cast a spell this turn")
 					return
 				}
 			}

--- a/game/cards/dm06/light_bringer.go
+++ b/game/cards/dm06/light_bringer.go
@@ -16,7 +16,7 @@ func VessTheOracle(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers)
 }
 
 func YulukTheOracle(c *match.Card) {

--- a/game/cards/dm06/light_bringer.go
+++ b/game/cards/dm06/light_bringer.go
@@ -30,28 +30,27 @@ func YulukTheOracle(c *match.Card) {
 
 	spellcast := false
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature,
+		fx.When(fx.IHaveCastASpell, func(card *match.Card, ctx *match.Context) { spellcast = true }),
+		func(card *match.Card, ctx *match.Context) {
 
-		if _, ok := ctx.Event.(*match.SpellCast); ok {
-			spellcast = true
-		}
-
-		_, ok := ctx.Event.(*match.EndStep)
-		if ok {
-			spellcast = false
-		}
-
-		if event, ok := ctx.Event.(*match.PlayCardEvent); ok {
-			if event.CardID == card.ID {
-				if !spellcast {
-					ctx.InterruptFlow()
-					ctx.Match.WarnPlayer(card.Player, "You can summon this creature only if you have cast a spell this turn")
-					return
-				}
+			// reset spellcast flag at the end of the turn
+			_, ok := ctx.Event.(*match.EndStep)
+			if ok {
+				spellcast = false
 			}
 
-		}
-	})
+			if event, ok := ctx.Event.(*match.PlayCardEvent); ok {
+				if event.CardID == card.ID {
+					if !spellcast {
+						ctx.InterruptFlow()
+						ctx.Match.WarnPlayer(card.Player, "You can summon this creature only if you have cast a spell this turn")
+						return
+					}
+				}
+
+			}
+		})
 }
 
 func AdomisTheOracle(c *match.Card) {

--- a/game/cards/dm06/liquid_people.go
+++ b/game/cards/dm06/liquid_people.go
@@ -29,5 +29,19 @@ func AquaRider(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, ReceiveBlockerWhenOpponentPlaysCreatureOrSpell)
+	isBlocker := false
+
+	c.Use(fx.Creature,
+		fx.When(ReceiveBlockerWhenOpponentPlaysCreatureOrSpell,
+			func(c *match.Card, ctx *match.Context) { isBlocker = true }),
+		fx.When(fx.EndOfTurn,
+			func(c *match.Card, ctx *match.Context) {
+				isBlocker = false
+				c.RemoveConditionBySource(c.ID)
+			}),
+		fx.When(func(c *match.Card, ctx *match.Context) bool { return isBlocker },
+			func(c *match.Card, ctx *match.Context) {
+				fx.ForceBlocker(c, ctx, c.ID)
+			}),
+	)
 }

--- a/game/cards/dm06/mecha_thunder.go
+++ b/game/cards/dm06/mecha_thunder.go
@@ -30,14 +30,14 @@ func DavaToreySeekerOfClouds(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx2 *match.Context) {
+	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx2.Event.(*match.CardMoved); ok {
+		if event, ok := ctx.Event.(*match.CardMoved); ok {
 			if event.CardID == card.ID && event.From == match.HAND && event.To == match.GRAVEYARD {
-				if !ctx2.Match.IsPlayerTurn(card.Player) {
-					ctx2.ScheduleAfter(func() {
+				if !ctx.Match.IsPlayerTurn(card.Player) {
+					ctx.ScheduleAfter(func() {
 						card.Player.MoveCard(card.ID, match.GRAVEYARD, match.BATTLEZONE, card.ID)
-						ctx2.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was discarded and moved to the battle zone", card.Name))
+						ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was discarded and moved to the battle zone", card.Name))
 					})
 
 				}

--- a/game/cards/dm06/mecha_thunder.go
+++ b/game/cards/dm06/mecha_thunder.go
@@ -17,7 +17,7 @@ func LaveilSeekerOfCatastrophe(c *match.Card) {
 	c.ManaCost = 8
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.Doublebreaker, fx.When(fx.EndOfMyTurnCreatureBZ, fx.MayUntapSelf))
+	c.Use(fx.Creature, fx.Blocker(), fx.Doublebreaker, fx.When(fx.EndOfMyTurnCreatureBZ, fx.MayUntapSelf))
 
 }
 

--- a/game/cards/dm06/mystery_totem.go
+++ b/game/cards/dm06/mystery_totem.go
@@ -48,7 +48,7 @@ func ClobberTotem(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.PowerAttacker2000, fx.Doublebreaker, fx.When(fx.Attacking, fx.CantBeBlockedByPowerUpTo5000))
+	c.Use(fx.Creature, fx.PowerAttacker2000, fx.Doublebreaker, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo5000))
 }
 
 func ForbiddingTotem(c *match.Card) {

--- a/game/cards/dm06/mystery_totem.go
+++ b/game/cards/dm06/mystery_totem.go
@@ -48,7 +48,7 @@ func ClobberTotem(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.PowerAttacker2000, fx.Doublebreaker, fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo5000))
+	c.Use(fx.Creature, fx.PowerAttacker2000, fx.Doublebreaker, fx.CantBeBlockedByPowerUpTo5000)
 }
 
 func ForbiddingTotem(c *match.Card) {

--- a/game/cards/dm06/rainbow_phantom.go
+++ b/game/cards/dm06/rainbow_phantom.go
@@ -49,29 +49,27 @@ func MoontearSpectralKnight(c *match.Card) {
 
 	spellcast := false
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature,
+		fx.When(fx.IHaveCastASpell, func(card *match.Card, ctx *match.Context) { spellcast = true }),
+		func(card *match.Card, ctx *match.Context) {
 
-		if _, ok := ctx.Event.(*match.SpellCast); ok {
-			spellcast = true
-		}
-
-		// remove persistent effect when turn ends
-		_, ok := ctx.Event.(*match.EndStep)
-		if ok {
-			spellcast = false
-		}
-
-		if event, ok := ctx.Event.(*match.PlayCardEvent); ok {
-			if event.CardID == card.ID {
-				if !spellcast {
-					ctx.InterruptFlow()
-					ctx.Match.WarnPlayer(card.Player, "You can summon this creature only if you have cast a spell this round")
-					return
-				}
+			// reset spellcast flag at the end of the turn
+			_, ok := ctx.Event.(*match.EndStep)
+			if ok {
+				spellcast = false
 			}
 
-		}
+			if event, ok := ctx.Event.(*match.PlayCardEvent); ok {
+				if event.CardID == card.ID {
+					if !spellcast {
+						ctx.InterruptFlow()
+						ctx.Match.WarnPlayer(card.Player, "You can summon this creature only if you have cast a spell this round")
+						return
+					}
+				}
 
-	})
+			}
+
+		})
 
 }

--- a/game/cards/dm06/sea_hacker.go
+++ b/game/cards/dm06/sea_hacker.go
@@ -29,7 +29,7 @@ func Zepimeteus(c *match.Card) {
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackCreatures, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers)
 }
 
 func PromephiusQ(c *match.Card) {

--- a/game/cards/dm06/xenoparts.go
+++ b/game/cards/dm06/xenoparts.go
@@ -6,6 +6,7 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 func PicorasWrench(c *match.Card) {
@@ -29,16 +30,17 @@ func RikabusScrewdriver(c *match.Card) {
 	c.ManaCost = 2
 	c.ManaRequirement = []string{civ.Fire}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
-		fx.SelectFilterSelectablesOnly(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),
 			match.BATTLEZONE,
-			"Rikabu's Screwdriver: You may destroy one of your opponent's blockers",
+			fmt.Sprintf("%s: You may destroy one of your opponent's blockers", card.Name),
 			1,
 			1,
 			true,
 			func(x *match.Card) bool { return x.HasCondition(cnd.Blocker) },
+			false,
 		).Map(func(x *match.Card) {
 			ctx.Match.Destroy(x, card, match.DestroyedByMiscAbility)
 		})

--- a/game/cards/dm07/chimera.go
+++ b/game/cards/dm07/chimera.go
@@ -28,5 +28,5 @@ func Gigabuster(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantAttackPlayers, fx.CantAttackCreatures, fx.When(fx.Summoned, fx.PutShieldIntoHand))
+	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackPlayers, fx.CantAttackCreatures, fx.When(fx.Summoned, fx.PutShieldIntoHand))
 }

--- a/game/cards/dm07/cyber_cluster.go
+++ b/game/cards/dm07/cyber_cluster.go
@@ -16,5 +16,5 @@ func TitaniumCluster(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Water}
 
-	c.Use(fx.Creature, fx.Blocker, fx.CantBeAttacked, fx.CantAttackCreatures, fx.CantAttackPlayers)
+	c.Use(fx.Creature, fx.Blocker(), fx.CantBeAttacked, fx.CantAttackCreatures, fx.CantAttackPlayers)
 }

--- a/game/cards/dm07/giant.go
+++ b/game/cards/dm07/giant.go
@@ -23,16 +23,16 @@ func HeadlongGiant(c *match.Card) {
 			if err != nil {
 				return
 			}
+
 			if len(hand) == 0 {
 				ctx.InterruptFlow()
 				ctx.Match.WarnPlayer(card.Player, fmt.Sprintf("%s can't attack if you don't have cards in hand", card.Name))
 			}
-
-			fx.CantBeBlockedByPowerUpTo4000(card, ctx)
 		}),
-		fx.WheneverThisAttacks(func(c *match.Card, ctx2 *match.Context) {
+		fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo4000),
+		fx.When(fx.AttackConfirmed, func(c *match.Card, ctx2 *match.Context) {
 			fx.Select(c.Player, ctx2.Match, c.Player, match.HAND,
-				"Headlong Giant effect: select a card to discard", 1, 1, false,
+				fmt.Sprintf("%s: select a card to discard", c.Name), 1, 1, false,
 			).Map(func(x *match.Card) {
 				c.Player.MoveCard(x.ID, match.HAND, match.GRAVEYARD, c.ID)
 			})

--- a/game/cards/dm07/giant.go
+++ b/game/cards/dm07/giant.go
@@ -29,7 +29,7 @@ func HeadlongGiant(c *match.Card) {
 				ctx.Match.WarnPlayer(card.Player, fmt.Sprintf("%s can't attack if you don't have cards in hand", card.Name))
 			}
 		}),
-		fx.When(fx.BlockerSelectionStep, fx.CantBeBlockedByPowerUpTo4000),
+		fx.CantBeBlockedByPowerUpTo4000,
 		fx.When(fx.AttackConfirmed, func(c *match.Card, ctx2 *match.Context) {
 			fx.Select(c.Player, ctx2.Match, c.Player, match.HAND,
 				fmt.Sprintf("%s: select a card to discard", c.Name), 1, 1, false,

--- a/game/cards/dm07/initiate.go
+++ b/game/cards/dm07/initiate.go
@@ -16,7 +16,7 @@ func KizarBasikuTheOutrageous(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, fx.Blocker, fx.Evolution, fx.FireStealth, fx.Doublebreaker)
+	c.Use(fx.Creature, fx.Blocker(), fx.Evolution, fx.FireStealth, fx.Doublebreaker)
 }
 
 func RomVizierofTendrils(c *match.Card) {

--- a/game/cards/dm07/leviathan.go
+++ b/game/cards/dm07/leviathan.go
@@ -22,7 +22,7 @@ func KingBenthos(c *match.Card) {
 			match.BATTLEZONE,
 			func(card *match.Card) bool { return card.Civ == civ.Water },
 		).Map(func(x *match.Card) {
-			x.AddCondition(cnd.CantBeBlocked, nil, card.ID)
+			x.AddUniqueSourceCondition(cnd.CantBeBlocked, nil, card.ID)
 		})
 	}
 

--- a/game/cards/dm07/mecha_thunder.go
+++ b/game/cards/dm07/mecha_thunder.go
@@ -26,7 +26,7 @@ func GandarSeekerofExplosions(c *match.Card) {
 				).Map(func(x *match.Card) {
 					if x.Tapped && x.Civ == civ.Light {
 						x.Tapped = false
-						ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was untapped by %s's effect", x.Name, card.Name))
+						ctx2.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was untapped by %s's effect", x.Name, card.Name))
 					}
 				})
 				exit()

--- a/game/cards/dm07/mystery_totem.go
+++ b/game/cards/dm07/mystery_totem.go
@@ -42,7 +42,7 @@ func SpinningTotem(c *match.Card) {
 					return
 				}
 
-				fx.DestoryOpShield(card, ctx)
+				fx.DestoryOpShield(card, ctx2)
 			}
 
 			// remove persistent effect when turn ends

--- a/game/cards/dm07/sea_hacker.go
+++ b/game/cards/dm07/sea_hacker.go
@@ -42,7 +42,7 @@ func Biancus(c *match.Card) {
 	c.ManaRequirement = []string{civ.Water}
 	c.TapAbility = fx.GiveOwnCreatureCantBeBlocked
 
-	c.Use(fx.Creature, fx.Blocker, fx.TapAbility)
+	c.Use(fx.Creature, fx.Blocker(), fx.TapAbility)
 }
 
 func Cetibols(c *match.Card) {

--- a/game/cards/dm07/spells.go
+++ b/game/cards/dm07/spells.go
@@ -140,16 +140,16 @@ func FruitOfEternity(c *match.Card) {
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
-		ctx.Match.ApplyPersistentEffect(func(ctx *match.Context, exit func()) {
+		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 
-			if event, ok := ctx.Event.(*match.CreatureDestroyed); ok && event.Card.Player == card.Player {
-				ctx.InterruptFlow()
+			if event, ok := ctx2.Event.(*match.CreatureDestroyed); ok && event.Card.Player == card.Player {
+				ctx2.InterruptFlow()
 				card.Player.MoveCard(event.Card.ID, match.BATTLEZONE, match.MANAZONE, card.ID)
-				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed but moved to manazone because of %s", event.Card.Name, card.Name))
+				ctx2.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was destroyed but moved to manazone because of %s", event.Card.Name, card.Name))
 			}
 
 			// remove persistent effect when turn ends
-			_, ok := ctx.Event.(*match.EndStep)
+			_, ok := ctx2.Event.(*match.EndStep)
 			if ok {
 				exit()
 			}

--- a/game/cards/dm07/starlight_tree.go
+++ b/game/cards/dm07/starlight_tree.go
@@ -52,7 +52,7 @@ func PulsarTree(c *match.Card) {
 					event.Cards = validShields
 				}
 
-				ctx.Match.ReportActionInChat(card.Player, "Pulsar tree destoryed to protect a shield.")
+				ctx.Match.ReportActionInChat(card.Player, "Pulsar tree destroyed to protect a shield.")
 				ctx.Match.Destroy(card, card, match.DestroyedByMiscAbility)
 			})
 		})

--- a/game/cards/dm08/zombie_dragon.go
+++ b/game/cards/dm08/zombie_dragon.go
@@ -30,12 +30,13 @@ func NecrodragonGalbazeek(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Darkness}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 		fx.SelectBackside(
 			card.Player,
-			ctx.Match, card.Player,
+			ctx.Match,
+			card.Player,
 			match.SHIELDZONE,
-			"Select one shield and send it to graveyard",
+			"Select one of your shields and put it into your graveyard",
 			1,
 			1,
 			false,

--- a/game/cards/promo/angel_command.go
+++ b/game/cards/promo/angel_command.go
@@ -18,17 +18,13 @@ func AmnisHolyElemental(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Creature,
-		fx.ConditionalBlocker(func(target *match.Card) bool {
-			return target.Civ == civ.Darkness
-		}),
+		fx.DarknessBlocker,
 		func(card *match.Card, ctx *match.Context) {
 
 			if event, ok := ctx.Event.(*match.CreatureDestroyed); ok && event.Card == card {
-
 				if event.Context == match.DestroyedInBattle && event.Source.Civ == civ.Darkness {
 					ctx.InterruptFlow()
 				}
-
 			}
 
 		})

--- a/game/cards/promo/angel_command.go
+++ b/game/cards/promo/angel_command.go
@@ -18,7 +18,7 @@ func AmnisHolyElemental(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Creature,
-		fx.DarknessBlocker,
+		fx.DarknessBlocker(),
 		func(card *match.Card, ctx *match.Context) {
 
 			if event, ok := ctx.Event.(*match.CreatureDestroyed); ok && event.Card == card {

--- a/game/cards/promo/demon_command.go
+++ b/game/cards/promo/demon_command.go
@@ -32,17 +32,13 @@ func GiliamTheTormentor(c *match.Card) {
 	c.ManaRequirement = []string{civ.Darkness}
 
 	c.Use(fx.Creature,
-		fx.ConditionalBlocker(func(target *match.Card) bool {
-			return target.Civ == civ.Light
-		}),
+		fx.LightBlocker,
 		func(card *match.Card, ctx *match.Context) {
 
 			if event, ok := ctx.Event.(*match.CreatureDestroyed); ok && event.Card == card {
-
 				if event.Context == match.DestroyedInBattle && event.Source.Civ == civ.Light {
 					ctx.InterruptFlow()
 				}
-
 			}
 
 		})

--- a/game/cards/promo/demon_command.go
+++ b/game/cards/promo/demon_command.go
@@ -32,7 +32,7 @@ func GiliamTheTormentor(c *match.Card) {
 	c.ManaRequirement = []string{civ.Darkness}
 
 	c.Use(fx.Creature,
-		fx.LightBlocker,
+		fx.LightBlocker(),
 		func(card *match.Card, ctx *match.Context) {
 
 			if event, ok := ctx.Event.(*match.CreatureDestroyed); ok && event.Card == card {

--- a/game/fx/blocker.go
+++ b/game/fx/blocker.go
@@ -1,14 +1,52 @@
 package fx
 
 import (
+	"duel-masters/game/civ"
 	"duel-masters/game/cnd"
 	"duel-masters/game/match"
 )
 
-type BlockerCondition func(target *match.Card) bool
-
-// Blocker adds the card to a list of blockers when a creature/player is attacked
+// Blocker adds the Blocker condition at the Untap step and
+// Adds the card to the blockers list at the SelectBlockers step if eligible
 func Blocker(card *match.Card, ctx *match.Context) {
+
+	addBlockerCondition(card, ctx)
+
+	defaultBlocker(card, ctx)
+
+}
+
+func FireAndNatureBlocker(card *match.Card, ctx *match.Context) {
+
+	addBlockerCondition(card, ctx)
+
+	conditionalBlocker(card, ctx, func(attacker *match.Card) bool {
+		return attacker.Civ == civ.Fire || attacker.Civ == civ.Nature
+	})
+
+}
+
+func DarknessBlocker(card *match.Card, ctx *match.Context) {
+
+	addBlockerCondition(card, ctx)
+
+	conditionalBlocker(card, ctx, func(attacker *match.Card) bool {
+		return attacker.Civ == civ.Darkness
+	})
+
+}
+
+func LightBlocker(card *match.Card, ctx *match.Context) {
+
+	addBlockerCondition(card, ctx)
+
+	conditionalBlocker(card, ctx, func(attacker *match.Card) bool {
+		return attacker.Civ == civ.Light
+	})
+
+}
+
+func addBlockerCondition(card *match.Card, ctx *match.Context) {
 
 	if _, ok := ctx.Event.(*match.UntapStep); ok {
 
@@ -18,10 +56,28 @@ func Blocker(card *match.Card, ctx *match.Context) {
 
 }
 
-func ConditionalBlocker(condition BlockerCondition) func(card *match.Card, ctx *match.Context) {
-	return func(card *match.Card, ctx *match.Context) {
-		if _, ok := ctx.Event.(*match.UntapStep); ok {
-			card.AddCondition(cnd.Blocker, condition, card.ID)
+func defaultBlocker(card *match.Card, ctx *match.Context) {
+	conditionalBlocker(card, ctx, nil)
+}
+
+func conditionalBlocker(card *match.Card, ctx *match.Context, attackerTest func(*match.Card) bool) {
+
+	// Check to see if I'm eligible to actually block the attack
+	// (I'm in the battlezone AND I'm untapped AND opponent doesn't attack me)
+	if event, ok := ctx.Event.(*match.SelectBlockers); ok &&
+		card.Zone == match.BATTLEZONE &&
+		(event.AttackedCard == nil || event.AttackedCard != card) &&
+		!card.Tapped {
+
+		// ONLY if the attacker card (event.CardWhoAttacked) passes the test function (if given)
+		// and is my opponent who attacks me
+		// add myself to the blockers list
+		if event.CardWhoAttacked.Zone == match.BATTLEZONE &&
+			card.Player != event.CardWhoAttacked.Player &&
+			(attackerTest == nil || attackerTest(event.CardWhoAttacked)) {
+			event.Blockers = append(event.Blockers, card)
 		}
+
 	}
+
 }

--- a/game/fx/blocker.go
+++ b/game/fx/blocker.go
@@ -4,23 +4,33 @@ import (
 	"duel-masters/game/civ"
 	"duel-masters/game/cnd"
 	"duel-masters/game/match"
+	"slices"
 )
 
 // Blocker adds the Blocker condition at the Untap step and
 // Adds the card to the blockers list at the SelectBlockers step if eligible
 func Blocker(card *match.Card, ctx *match.Context) {
 
-	addBlockerCondition(card, ctx)
+	addDefaultBlockerCondition(card, ctx, false, nil)
 
-	defaultBlocker(card, ctx)
+	addDefaultBlocker(card, ctx)
 
+}
+
+// ForceBlocker adds the Blocker condition, no matter the current handled event
+// And adds the card to the blockers list at the SelectBlockers step if eligible
+func ForceBlocker(card *match.Card, ctx *match.Context, src any) {
+
+	forceAddBlockerCondition(card, src)
+
+	addDefaultBlocker(card, ctx)
 }
 
 func FireAndNatureBlocker(card *match.Card, ctx *match.Context) {
 
-	addBlockerCondition(card, ctx)
+	addDefaultBlockerCondition(card, ctx, false, nil)
 
-	conditionalBlocker(card, ctx, func(attacker *match.Card) bool {
+	addConditionalBlocker(card, ctx, func(attacker *match.Card) bool {
 		return attacker.Civ == civ.Fire || attacker.Civ == civ.Nature
 	})
 
@@ -28,9 +38,9 @@ func FireAndNatureBlocker(card *match.Card, ctx *match.Context) {
 
 func DarknessBlocker(card *match.Card, ctx *match.Context) {
 
-	addBlockerCondition(card, ctx)
+	addDefaultBlockerCondition(card, ctx, false, nil)
 
-	conditionalBlocker(card, ctx, func(attacker *match.Card) bool {
+	addConditionalBlocker(card, ctx, func(attacker *match.Card) bool {
 		return attacker.Civ == civ.Darkness
 	})
 
@@ -38,43 +48,53 @@ func DarknessBlocker(card *match.Card, ctx *match.Context) {
 
 func LightBlocker(card *match.Card, ctx *match.Context) {
 
-	addBlockerCondition(card, ctx)
+	addDefaultBlockerCondition(card, ctx, false, nil)
 
-	conditionalBlocker(card, ctx, func(attacker *match.Card) bool {
+	addConditionalBlocker(card, ctx, func(attacker *match.Card) bool {
 		return attacker.Civ == civ.Light
 	})
 
 }
 
-func addBlockerCondition(card *match.Card, ctx *match.Context) {
+func addDefaultBlockerCondition(card *match.Card, ctx *match.Context, uniqueCond bool, src any) {
 
 	if _, ok := ctx.Event.(*match.UntapStep); ok {
 
-		card.AddCondition(cnd.Blocker, true, card.ID)
+		if uniqueCond {
+			card.AddUniqueSourceCondition(cnd.Blocker, true, src)
+		} else {
+			card.AddCondition(cnd.Blocker, true, card.ID)
+		}
 
 	}
 
 }
 
-func defaultBlocker(card *match.Card, ctx *match.Context) {
-	conditionalBlocker(card, ctx, nil)
+func forceAddBlockerCondition(card *match.Card, src any) {
+	card.AddUniqueSourceCondition(cnd.Blocker, true, src)
 }
 
-func conditionalBlocker(card *match.Card, ctx *match.Context, attackerTest func(*match.Card) bool) {
+func addDefaultBlocker(card *match.Card, ctx *match.Context) {
+	addConditionalBlocker(card, ctx, nil)
+}
+
+func addConditionalBlocker(card *match.Card, ctx *match.Context, attackerTest func(*match.Card) bool) {
 
 	// Check to see if I'm eligible to actually block the attack
 	// (I'm in the battlezone AND I'm untapped AND opponent doesn't attack me)
 	if event, ok := ctx.Event.(*match.SelectBlockers); ok &&
 		card.Zone == match.BATTLEZONE &&
 		(event.AttackedCard == nil || event.AttackedCard != card) &&
-		!card.Tapped {
+		!card.Tapped &&
+		card.HasCondition(cnd.Blocker) {
 
 		// ONLY if the attacker card (event.CardWhoAttacked) passes the test function (if given)
 		// and is my opponent who attacks me
 		// add myself to the blockers list
 		if event.CardWhoAttacked.Zone == match.BATTLEZONE &&
 			card.Player != event.CardWhoAttacked.Player &&
-			(attackerTest == nil || attackerTest(event.CardWhoAttacked)) {
+			(attackerTest == nil || attackerTest(event.CardWhoAttacked)) &&
+			!slices.Contains(event.Blockers, card) {
 			event.Blockers = append(event.Blockers, card)
 		}
 

--- a/game/fx/cant_be_attacked.go
+++ b/game/fx/cant_be_attacked.go
@@ -5,7 +5,7 @@ import (
 	"duel-masters/game/match"
 )
 
-// CantBeBlocked allows the card to attack without being blocked
+// CantBeAttacked
 func CantBeAttacked(card *match.Card, ctx *match.Context) {
 
 	if _, ok := ctx.Event.(*match.UntapStep); ok {
@@ -33,7 +33,7 @@ func CantBeAttackedIf(test func(attacker *match.Card) bool) func(*match.Card, *m
 				}
 			}
 
-			if me != true {
+			if !me {
 				return
 			}
 

--- a/game/fx/cant_be_blocked.go
+++ b/game/fx/cant_be_blocked.go
@@ -16,7 +16,7 @@ func CantBeBlocked(card *match.Card, ctx *match.Context) {
 
 }
 
-// CantBeBlockedBy
+// CantBeBlockedIf
 func CantBeBlockedIf(test func(blocker *match.Card) bool) func(*match.Card, *match.Context) {
 
 	return func(card *match.Card, ctx *match.Context) {

--- a/game/fx/cant_be_blocked.go
+++ b/game/fx/cant_be_blocked.go
@@ -29,14 +29,14 @@ func GiveOwnCreatureCantBeBlocked(card *match.Card, ctx *match.Context) {
 }
 
 func CantBeBlockedByDarkness(card *match.Card, ctx *match.Context) {
-	cantBeBlockedIf(card, ctx, func(blocker *match.Card) bool {
-		return blocker.Civ == civ.Darkness
+	filterBlocker(card, ctx, func(blocker *match.Card) bool {
+		return blocker.Civ != civ.Darkness
 	})
 }
 
 func CantBeBlockedByLight(card *match.Card, ctx *match.Context) {
-	cantBeBlockedIf(card, ctx, func(blocker *match.Card) bool {
-		return blocker.Civ == civ.Light
+	filterBlocker(card, ctx, func(blocker *match.Card) bool {
+		return blocker.Civ != civ.Light
 	})
 }
 
@@ -61,25 +61,25 @@ func CantBeBlockedByPowerUpTo3000(card *match.Card, ctx *match.Context) {
 }
 
 func cantBeBlockedByPowerUpTo(card *match.Card, ctx *match.Context, power int) {
-	cantBeBlockedIf(card, ctx, func(blocker *match.Card) bool {
+	filterBlocker(card, ctx, func(blocker *match.Card) bool {
 		return ctx.Match.GetPower(blocker, false) > power
 	})
 }
 
 func cantBeBlockedByPowerXOrMore(card *match.Card, ctx *match.Context, power int) {
-	cantBeBlockedIf(card, ctx, func(blocker *match.Card) bool {
+	filterBlocker(card, ctx, func(blocker *match.Card) bool {
 		return ctx.Match.GetPower(blocker, false) < power
 	})
 }
 
-// CantBeBlockedIf
-func cantBeBlockedIf(card *match.Card, ctx *match.Context, test func(blocker *match.Card) bool) {
+// filterBlocker
+func filterBlocker(card *match.Card, ctx *match.Context, test func(blocker *match.Card) bool) {
 
 	filter := func(blockers []*match.Card) []*match.Card {
 		filtered := []*match.Card{}
 
 		for _, b := range blockers {
-			if !test(b) {
+			if test(b) {
 				filtered = append(filtered, b)
 			}
 		}

--- a/game/fx/cant_be_blocked.go
+++ b/game/fx/cant_be_blocked.go
@@ -22,7 +22,7 @@ func GiveOwnCreatureCantBeBlocked(card *match.Card, ctx *match.Context) {
 	Select(card.Player, ctx.Match, card.Player, match.BATTLEZONE,
 		"Choose a card to receive 'Can't be blocked this turn'", 1, 1, false,
 	).Map(func(x *match.Card) {
-		x.AddCondition(cnd.CantBeBlocked, nil, card.ID)
+		x.AddUniqueSourceCondition(cnd.CantBeBlocked, nil, card.ID)
 		ctx.Match.ReportActionInChat(card.Player,
 			fmt.Sprintf("%s tap effect: %s can't be blocked this turn", card.Name, x.Name))
 	})

--- a/game/fx/cant_be_blocked.go
+++ b/game/fx/cant_be_blocked.go
@@ -88,8 +88,8 @@ func filterBlocker(card *match.Card, ctx *match.Context, test func(blocker *matc
 	}
 
 	if event, ok := ctx.Event.(*match.SelectBlockers); ok &&
-		event.CardWhoAttacked == card &&
-		event.CardWhoAttacked.Zone == match.BATTLEZONE {
+		event.Attacker == card &&
+		event.Attacker.Zone == match.BATTLEZONE {
 
 		ctx.ScheduleAfter(func() {
 			event.Blockers = filter(event.Blockers)

--- a/game/fx/cant_be_blocked.go
+++ b/game/fx/cant_be_blocked.go
@@ -1,8 +1,10 @@
 package fx
 
 import (
+	"duel-masters/game/civ"
 	"duel-masters/game/cnd"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 // CantBeBlocked allows the card to attack without being blocked
@@ -16,38 +18,82 @@ func CantBeBlocked(card *match.Card, ctx *match.Context) {
 
 }
 
+func GiveOwnCreatureCantBeBlocked(card *match.Card, ctx *match.Context) {
+	Select(card.Player, ctx.Match, card.Player, match.BATTLEZONE,
+		"Choose a card to receive 'Can't be blocked this turn'", 1, 1, false,
+	).Map(func(x *match.Card) {
+		x.AddCondition(cnd.CantBeBlocked, nil, card.ID)
+		ctx.Match.ReportActionInChat(card.Player,
+			fmt.Sprintf("%s tap effect: %s can't be blocked this turn", card.Name, x.Name))
+	})
+}
+
+func CantBeBlockedByDarkness(card *match.Card, ctx *match.Context) {
+	cantBeBlockedIf(card, ctx, func(blocker *match.Card) bool {
+		return blocker.Civ == civ.Darkness
+	})
+}
+
+func CantBeBlockedByLight(card *match.Card, ctx *match.Context) {
+	cantBeBlockedIf(card, ctx, func(blocker *match.Card) bool {
+		return blocker.Civ == civ.Light
+	})
+}
+
+func CantBeBlockedByPower4000OrMore(card *match.Card, ctx *match.Context) {
+	cantBeBlockedByPowerXOrMore(card, ctx, 4000)
+}
+
+func CantBeBlockedByPowerUpTo4000(card *match.Card, ctx *match.Context) {
+	cantBeBlockedByPowerUpTo(card, ctx, 4000)
+}
+
+func CantBeBlockedByPowerUpTo5000(card *match.Card, ctx *match.Context) {
+	cantBeBlockedByPowerUpTo(card, ctx, 5000)
+}
+
+func CantBeBlockedByPowerUpTo8000(card *match.Card, ctx *match.Context) {
+	cantBeBlockedByPowerUpTo(card, ctx, 8000)
+}
+
+func CantBeBlockedByPowerUpTo3000(card *match.Card, ctx *match.Context) {
+	cantBeBlockedByPowerUpTo(card, ctx, 3000)
+}
+
+func cantBeBlockedByPowerUpTo(card *match.Card, ctx *match.Context, power int) {
+	cantBeBlockedIf(card, ctx, func(blocker *match.Card) bool {
+		return ctx.Match.GetPower(blocker, false) > power
+	})
+}
+
+func cantBeBlockedByPowerXOrMore(card *match.Card, ctx *match.Context, power int) {
+	cantBeBlockedIf(card, ctx, func(blocker *match.Card) bool {
+		return ctx.Match.GetPower(blocker, false) < power
+	})
+}
+
 // CantBeBlockedIf
-func CantBeBlockedIf(test func(blocker *match.Card) bool) func(*match.Card, *match.Context) {
+func cantBeBlockedIf(card *match.Card, ctx *match.Context, test func(blocker *match.Card) bool) {
 
-	return func(card *match.Card, ctx *match.Context) {
+	filter := func(blockers []*match.Card) []*match.Card {
+		filtered := []*match.Card{}
 
-		filter := func(blockers []*match.Card) []*match.Card {
-			filtered := []*match.Card{}
-
-			for _, b := range blockers {
-				if !test(b) {
-					filtered = append(filtered, b)
-				}
+		for _, b := range blockers {
+			if !test(b) {
+				filtered = append(filtered, b)
 			}
-
-			return filtered
 		}
 
-		switch event := ctx.Event.(type) {
+		return filtered
+	}
 
-		case *match.AttackCreature:
-			if event.CardID != card.ID {
-				return
-			}
+	if event, ok := ctx.Event.(*match.SelectBlockers); ok &&
+		event.CardWhoAttacked == card &&
+		event.CardWhoAttacked.Zone == match.BATTLEZONE {
+
+		ctx.ScheduleAfter(func() {
 			event.Blockers = filter(event.Blockers)
-		case *match.AttackPlayer:
-			if event.CardID != card.ID {
-				return
-			}
-			event.Blockers = filter(event.Blockers)
-		default:
-			return
-		}
+		})
 
 	}
 

--- a/game/fx/common_effects.go
+++ b/game/fx/common_effects.go
@@ -92,11 +92,10 @@ func BlockerWhenNoShields(card *match.Card, ctx *match.Context) {
 }
 
 func HaveSelfConditionsWhenNoShields(card *match.Card, ctx *match.Context, conditions []*match.Condition) {
-
 	ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 
 		notInTheBZ := card.Zone != match.BATTLEZONE
-		if notInTheBZ || IHaveShields(card, ctx2) {
+		if notInTheBZ || IHaveShields(card) {
 			for _, cond := range conditions {
 				card.RemoveSpecificConditionBySource(cond.ID, card.ID)
 			}

--- a/game/fx/common_effects.go
+++ b/game/fx/common_effects.go
@@ -87,7 +87,7 @@ func ShuffleDeck(card *match.Card, ctx *match.Context, forOpponent bool) {
 }
 
 func BlockerWhenNoShields(card *match.Card, ctx *match.Context) {
-	condition := &match.Condition{ID: cnd.Blocker, Val: true, Src: nil}
+	condition := &match.Condition{ID: cnd.Blocker, Val: true, Src: card.ID}
 	HaveSelfConditionsWhenNoShields(card, ctx, []*match.Condition{condition})
 }
 
@@ -109,7 +109,11 @@ func HaveSelfConditionsWhenNoShields(card *match.Card, ctx *match.Context, condi
 
 		if IDontHaveShields(card, ctx2) {
 			for _, cond := range conditions {
-				card.AddUniqueSourceCondition(cond.ID, cond.Val, card.ID)
+				if cond.ID == cnd.Blocker {
+					ForceBlocker(card, ctx2, card.ID)
+				} else {
+					card.AddUniqueSourceCondition(cond.ID, cond.Val, card.ID)
+				}
 			}
 		}
 

--- a/game/fx/common_effects.go
+++ b/game/fx/common_effects.go
@@ -123,16 +123,6 @@ func CantBeBlockedByPowerUpTo3000(card *match.Card, ctx *match.Context) {
 	CantBeBlockedByPowerUpTo(card, ctx, 3000)
 }
 
-func RemoveBlockerFromList(card *match.Card, ctx *match.Context) {
-	blockersList := BlockersList(ctx)
-	var newBlockersList []*match.Card
-	for _, blocker := range *blockersList {
-		if blocker.ID != card.ID {
-			newBlockersList = append(newBlockersList, blocker)
-		}
-	}
-	*blockersList = newBlockersList
-}
 func BlockerWhenNoShields(card *match.Card, ctx *match.Context) {
 	condition := &match.Condition{ID: cnd.Blocker, Val: true, Src: nil}
 	HaveSelfConditionsWhenNoShields(card, ctx, []*match.Condition{condition})

--- a/game/fx/common_effects.go
+++ b/game/fx/common_effects.go
@@ -86,43 +86,6 @@ func ShuffleDeck(card *match.Card, ctx *match.Context, forOpponent bool) {
 
 }
 
-func CantBeBlockedByPowerUpTo(card *match.Card, ctx *match.Context, power int) {
-	blockersList := BlockersList(ctx)
-	var newBlockersList []*match.Card
-	for _, blocker := range *blockersList {
-		if ctx.Match.GetPower(blocker, false) > power {
-			newBlockersList = append(newBlockersList, blocker)
-		}
-	}
-	*blockersList = newBlockersList
-}
-
-func GiveOwnCreatureCantBeBlocked(card *match.Card, ctx *match.Context) {
-	Select(card.Player, ctx.Match, card.Player, match.BATTLEZONE,
-		"Choose a card to receive 'Can't be blocked this turn'", 1, 1, false,
-	).Map(func(x *match.Card) {
-		x.AddCondition(cnd.CantBeBlocked, nil, card.ID)
-		ctx.Match.ReportActionInChat(card.Player,
-			fmt.Sprintf("%s tap effect: %s can't be blocked this turn", card.Name, x.Name))
-	})
-}
-
-func CantBeBlockedByPowerUpTo4000(card *match.Card, ctx *match.Context) {
-	CantBeBlockedByPowerUpTo(card, ctx, 4000)
-}
-
-func CantBeBlockedByPowerUpTo5000(card *match.Card, ctx *match.Context) {
-	CantBeBlockedByPowerUpTo(card, ctx, 5000)
-}
-
-func CantBeBlockedByPowerUpTo8000(card *match.Card, ctx *match.Context) {
-	CantBeBlockedByPowerUpTo(card, ctx, 8000)
-}
-
-func CantBeBlockedByPowerUpTo3000(card *match.Card, ctx *match.Context) {
-	CantBeBlockedByPowerUpTo(card, ctx, 3000)
-}
-
 func BlockerWhenNoShields(card *match.Card, ctx *match.Context) {
 	condition := &match.Condition{ID: cnd.Blocker, Val: true, Src: nil}
 	HaveSelfConditionsWhenNoShields(card, ctx, []*match.Condition{condition})

--- a/game/fx/creature.go
+++ b/game/fx/creature.go
@@ -425,7 +425,7 @@ func Creature(card *match.Card, ctx *match.Context) {
 			// Broadcast state so that opponent can see that this card is tapped if they get any shield triggers
 			ctx.Match.BroadcastState()
 
-			// In case the attacker or creature was removed by a WheneverThisAttacksEffect
+			// In case the attacker or creature was removed by an AttackConfirmed effect
 			if card.Zone != match.BATTLEZONE || c.Zone != match.BATTLEZONE {
 				return
 			}

--- a/game/fx/creature.go
+++ b/game/fx/creature.go
@@ -665,13 +665,13 @@ func handleBattle(ctx *match.Context, winner *match.Card, winnerPower int, loose
 	ctx.Match.ReportActionInChat(looser.Player, fmt.Sprintf("%s (%v) was destroyed by %s (%v)", looser.Name, looserPower, winner.Name, winnerPower))
 	ctx.Match.HandleFx(match.NewContext(ctx.Match, &match.CreatureDestroyed{Card: looser, Source: winner, Blocked: blocked}))
 
-	// Destry after battle
+	// Destroy after battle
 	for _, condition := range winner.Conditions() {
-		if condition.ID != cnd.DestroyAfterBattle {
-			continue
-		}
+		if condition.ID == cnd.DestroyAfterBattle {
+			ctx.Match.Destroy(winner, winner, match.DestroyAfterBattle)
 
-		ctx.Match.Destroy(winner, winner, match.DestroyedBySlayer)
+			break
+		}
 	}
 
 	// Slayer

--- a/game/fx/draw.go
+++ b/game/fx/draw.go
@@ -15,7 +15,7 @@ func Draw2(card *match.Card, ctx *match.Context) {
 	card.Player.DrawCards(2)
 }
 
-// Draw1ToMana draws 1 card and puts it in the players manazone
+// Draw1ToMana draws 1 card and puts it in the player's manazone
 func Draw1ToMana(card *match.Card, ctx *match.Context) {
 
 	cards := card.Player.PeekDeck(1)

--- a/game/fx/draw.go
+++ b/game/fx/draw.go
@@ -34,6 +34,13 @@ func Draw1ToMana(card *match.Card, ctx *match.Context) {
 
 }
 
+// MayDraw1ToMana lets the player choose if they want to draw 1 card and put it in the players manazone
+func MayDraw1ToMana(card *match.Card, ctx *match.Context) {
+	if BinaryQuestion(card.Player, ctx.Match, fmt.Sprintf("Do you want to put your top card of your deck into your mana zone? (%s effect)", card.Name)) {
+		Draw1ToMana(card, ctx)
+	}
+}
+
 func Draw2ToMana(card *match.Card, ctx *match.Context) {
 	Draw1ToMana(card, ctx)
 	Draw1ToMana(card, ctx)

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -432,12 +432,8 @@ func SelectBacksideFilter(p *match.Player, m *match.Match, containerOwner *match
 // Convenience method to get blockers list for fx.Attacking regardless of the target
 func BlockersList(ctx *match.Context) *[]*match.Card {
 
-	if event, ok := ctx.Event.(*match.AttackCreature); ok {
-		return &event.Blockers
-	}
-
-	if event, ok := ctx.Event.(*match.AttackPlayer); ok {
-		return &event.Blockers
+	if event, ok := ctx.Event.(*match.BlockerSelectionStep); ok {
+		return event.Blockers
 	}
 
 	return nil
@@ -538,6 +534,18 @@ func AttackingPlayer(card *match.Card, ctx *match.Context) bool {
 func AttackingCreature(card *match.Card, ctx *match.Context) bool {
 
 	if event, ok := ctx.Event.(*match.AttackCreature); ok {
+		if event.CardID == card.ID {
+			return true
+		}
+	}
+
+	return false
+
+}
+
+func BlockerSelectionStep(card *match.Card, ctx *match.Context) bool {
+
+	if event, ok := ctx.Event.(*match.BlockerSelectionStep); ok {
 		if event.CardID == card.ID {
 			return true
 		}

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -716,7 +716,7 @@ func IDontHaveShields(card *match.Card, ctx *match.Context) bool {
 	return len(shields) == 0
 }
 
-func IHaveShields(card *match.Card, ctx *match.Context) bool {
+func IHaveShields(card *match.Card) bool {
 	shields, err := card.Player.Container(match.SHIELDZONE)
 	if err != nil {
 		return false

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -749,3 +749,17 @@ func Blocked(card *match.Card, ctx *match.Context) bool {
 	}
 	return false
 }
+
+func IHaveCastASpell(card *match.Card, ctx *match.Context) bool {
+	if event, ok := ctx.Event.(*match.SpellCast); ok {
+
+		// Check to see if I am the player who casted a spell
+		if (card.Player == ctx.Match.Player1.Player && event.MatchPlayerID == 1) ||
+			(card.Player == ctx.Match.Player2.Player && event.MatchPlayerID == 2) {
+			return true
+		}
+
+	}
+
+	return false
+}

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -429,17 +429,6 @@ func SelectBacksideFilter(p *match.Player, m *match.Match, containerOwner *match
 
 }
 
-// Convenience method to get blockers list for fx.Attacking regardless of the target
-func BlockersList(ctx *match.Context) *[]*match.Card {
-
-	if event, ok := ctx.Event.(*match.BlockerSelectionStep); ok {
-		return event.Blockers
-	}
-
-	return nil
-
-}
-
 // Hooks below:
 // hooks are shorthands for checking if the context matches a certain condition
 
@@ -534,18 +523,6 @@ func AttackingPlayer(card *match.Card, ctx *match.Context) bool {
 func AttackingCreature(card *match.Card, ctx *match.Context) bool {
 
 	if event, ok := ctx.Event.(*match.AttackCreature); ok {
-		if event.CardID == card.ID {
-			return true
-		}
-	}
-
-	return false
-
-}
-
-func BlockerSelectionStep(card *match.Card, ctx *match.Context) bool {
-
-	if event, ok := ctx.Event.(*match.BlockerSelectionStep); ok {
 		if event.CardID == card.ID {
 			return true
 		}

--- a/game/fx/tap_ability.go
+++ b/game/fx/tap_ability.go
@@ -5,7 +5,7 @@ import (
 	"duel-masters/game/match"
 )
 
-// Survivor adds the survivor condition every turn
+// Adds the tap ability condition every turn
 func TapAbility(card *match.Card, ctx *match.Context) {
 
 	if _, ok := ctx.Event.(*match.UntapStep); ok {

--- a/game/fx/whenever_this_attacks.go
+++ b/game/fx/whenever_this_attacks.go
@@ -2,21 +2,12 @@ package fx
 
 import (
 	"duel-masters/game/civ"
-	"duel-masters/game/cnd"
 	"duel-masters/game/match"
 	"fmt"
 )
 
-// Called for cards that use Whenever this attacks
-// If this function actions results in changes to the blockers, it should go ahead and modifiy it
-func WheneverThisAttacks(f func(*match.Card, *match.Context)) match.HandlerFunc {
-	return When(Attacking, func(c *match.Card, ctx2 *match.Context) {
-		c.AddUniqueSourceCondition(cnd.WheneverThisAttacks, f, c.ID)
-	})
-}
-
 func WheneverThisAttacksMayTapDorFCreature() match.HandlerFunc {
-	return WheneverThisAttacks(func(c *match.Card, ctx *match.Context) {
+	return When(AttackConfirmed, func(c *match.Card, ctx *match.Context) {
 		filter := func(x *match.Card) bool { return x.Civ == civ.Fire || x.Civ == civ.Darkness }
 		cards := make(map[string][]*match.Card)
 		cards["Your creatures"] = FindFilter(c.Player, match.BATTLEZONE, filter)
@@ -26,28 +17,25 @@ func WheneverThisAttacksMayTapDorFCreature() match.HandlerFunc {
 			c.Player,
 			ctx.Match,
 			cards,
-			fmt.Sprintf("%s: Select a card to tap or close to cancel", c.Name),
+			fmt.Sprintf("%s: You may select a darkness or fire creature in the battlezone to tap", c.Name),
 			1,
 			1,
 			true,
 		).Map(func(x *match.Card) {
 			x.Tapped = true
-			RemoveBlockerFromList(x, ctx)
 		})
 
 	})
 }
 
-// TODO: This is currently nerfed because we make shield selection to early in the attack.
-// In theory with this power they should make a more informed attack
 func WheneverThisAttacksMayLookAtOpShield() match.HandlerFunc {
-	return WheneverThisAttacks(func(card *match.Card, ctx *match.Context) {
+	return When(AttackConfirmed, func(card *match.Card, ctx *match.Context) {
 		SelectBackside(
 			card.Player,
 			ctx.Match,
 			ctx.Match.Opponent(card.Player),
 			match.SHIELDZONE,
-			fmt.Sprintf("%s: Select 1 of your opponent's shields that will be shown to you", card.Name),
+			fmt.Sprintf("%s: You may select 1 of your opponent's shields that will be shown to you", card.Name),
 			1,
 			1,
 			true,

--- a/game/match/card.go
+++ b/game/match/card.go
@@ -159,7 +159,7 @@ func (c *Card) RemoveConditionBySource(src string) {
 
 }
 
-// RemoveConditionBySource removes all instances of conditions with given source
+// RemoveConditionBySource removes all instances of specific conditions with given source
 func (c *Card) RemoveSpecificConditionBySource(cnd string, src string) {
 
 	tmp := make([]Condition, 0)

--- a/game/match/events.go
+++ b/game/match/events.go
@@ -89,9 +89,19 @@ type AttackConfirmed struct {
 }
 
 // SelectBlockers is fired after the AttackConfirmed effects,
-// right before the blocker selection pop-up.
-// Here, cards that have conditional CantBeBlocked effects must handle them.
+// Here, blockers (both normal and conditional) are added into the blockers list
+// and cards that have conditional CantBeBlocked effects handles them.
 type SelectBlockers struct {
+	CardWhoAttacked *Card // Card that attacks
+	Blockers        []*Card
+	Shieldzone      []*Card
+	ShieldsAttacked []*Card
+	AttackedCard    *Card
+}
+
+// BlockStep is fired when the opponent is prompted to select the blockers
+// Props are passed from SelectBlockers event
+type BlockStep struct {
 	CardWhoAttacked *Card // Card that attacks
 	Blockers        []*Card
 	Shieldzone      []*Card

--- a/game/match/events.go
+++ b/game/match/events.go
@@ -92,21 +92,18 @@ type AttackConfirmed struct {
 // Here, blockers (both normal and conditional) are added into the blockers list
 // and cards that have conditional CantBeBlocked effects handles them.
 type SelectBlockers struct {
-	CardWhoAttacked *Card // Card that attacks
-	Blockers        []*Card
-	Shieldzone      []*Card
-	ShieldsAttacked []*Card
-	AttackedCard    *Card
+	Attacker       *Card
+	Blockers       []*Card
+	AttackedCardID string // must be empty if the attack is on a player
 }
 
-// BlockStep is fired when the opponent is prompted to select the blockers
-// Props are passed from SelectBlockers event
-type BlockStep struct {
-	CardWhoAttacked *Card // Card that attacks
+// Block is fired when the opponent is prompted to select the blockers
+// Properties are passed from SelectBlockers event
+type Block struct {
+	Attacker        *Card
 	Blockers        []*Card
-	Shieldzone      []*Card
 	ShieldsAttacked []*Card
-	AttackedCard    *Card
+	AttackedCardID  string // must be empty if the attack is on a player
 }
 
 // Battle is fired when two creatures are fighting, i.e. from attacking a creature or blocking an attack
@@ -125,7 +122,6 @@ const (
 	DestroyedBySpell
 	DestroyedBySlayer
 	DestroyedByMiscAbility
-	DestroyAfterBattle
 )
 
 // CreatureDestroyed is fired when a creature dies in battle or is destroyed from another source, such as a spell

--- a/game/match/events.go
+++ b/game/match/events.go
@@ -75,11 +75,23 @@ type AttackPlayer struct {
 	Blockers []*Card
 }
 
+func (ap *AttackPlayer) GetBlockers() *[]*Card {
+	return &ap.Blockers
+}
+
 // AttackCreature is fired when the player attempts to use a creature to attack the player
 type AttackCreature struct {
 	CardID              string
 	Blockers            []*Card
 	AttackableCreatures []*Card // list of cards that can be attacked
+}
+
+func (ac *AttackCreature) GetBlockers() *[]*Card {
+	return &ac.Blockers
+}
+
+type BlockableAttack interface {
+	GetBlockers() *[]*Card
 }
 
 // AttackConfirmed is fired when either attacking a player or creature, but **after** the attack is validated
@@ -88,6 +100,14 @@ type AttackConfirmed struct {
 	CardID   string
 	Player   bool
 	Creature bool
+}
+
+// BlockersSelectionStep is fired when either attacking a player or creature, after the AttackConfirmed effects,
+// right before the blocker selection pop-up.
+// Here, cards that have conditional CantBeBlocked effects must handle them.
+type BlockerSelectionStep struct {
+	CardID   string
+	Blockers *[]*Card
 }
 
 // Battle is fired when two creatures are fighting, i.e. from attacking a creature or blocking an attack

--- a/game/match/events.go
+++ b/game/match/events.go
@@ -71,27 +71,13 @@ type SpellCast struct {
 
 // AttackPlayer is fired when the player attempts to use a creature to attack the player
 type AttackPlayer struct {
-	CardID   string
-	Blockers []*Card
-}
-
-func (ap *AttackPlayer) GetBlockers() *[]*Card {
-	return &ap.Blockers
+	CardID string
 }
 
 // AttackCreature is fired when the player attempts to use a creature to attack the player
 type AttackCreature struct {
 	CardID              string
-	Blockers            []*Card
 	AttackableCreatures []*Card // list of cards that can be attacked
-}
-
-func (ac *AttackCreature) GetBlockers() *[]*Card {
-	return &ac.Blockers
-}
-
-type BlockableAttack interface {
-	GetBlockers() *[]*Card
 }
 
 // AttackConfirmed is fired when either attacking a player or creature, but **after** the attack is validated
@@ -102,12 +88,15 @@ type AttackConfirmed struct {
 	Creature bool
 }
 
-// BlockersSelectionStep is fired when either attacking a player or creature, after the AttackConfirmed effects,
+// SelectBlockers is fired after the AttackConfirmed effects,
 // right before the blocker selection pop-up.
 // Here, cards that have conditional CantBeBlocked effects must handle them.
-type BlockerSelectionStep struct {
-	CardID   string
-	Blockers *[]*Card
+type SelectBlockers struct {
+	CardWhoAttacked *Card // Card that attacks
+	Blockers        []*Card
+	Shieldzone      []*Card
+	ShieldsAttacked []*Card
+	AttackedCard    *Card
 }
 
 // Battle is fired when two creatures are fighting, i.e. from attacking a creature or blocking an attack

--- a/game/match/events.go
+++ b/game/match/events.go
@@ -126,6 +126,7 @@ const (
 	DestroyedBySpell
 	DestroyedBySlayer
 	DestroyedByMiscAbility
+	DestroyAfterBattle
 )
 
 // CreatureDestroyed is fired when a creature dies in battle or is destroyed from another source, such as a spell

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -218,7 +218,6 @@ func (m *Match) Battle(attacker *Card, defender *Card, blocked bool) {
 	attackerPower := m.GetPower(attacker, true)
 	defenderPower := m.GetPower(defender, false)
 
-	m.HandleFx(NewContext(m, &AttackConfirmed{CardID: attacker.ID, Player: false, Creature: true}))
 	m.HandleFx(NewContext(m, &Battle{Attacker: attacker, AttackerPower: attackerPower, Defender: defender, DefenderPower: defenderPower, Blocked: blocked}))
 
 	m.BroadcastState()
@@ -1933,88 +1932,163 @@ func (p *PlayerReference) Dispose() {
 
 func (m *Match) handleAdminMessages(message string, user db.User) {
 
+	if !hasAdminRightsAndValidMsgFormat(message, user) {
+		return
+	}
+
+	handleAdminCommandCases(m, message)
+}
+
+func hasAdminRightsAndValidMsgFormat(message string, user db.User) bool {
+
 	hasRights := false
 
 	for _, permission := range user.Permissions {
 		if permission == "admin" {
 			hasRights = true
+			break
 		}
 	}
 
 	if !hasRights {
-		return
+		return false
 	}
 
+	msgParts := strings.Split(message, " ")
+
+	return len(msgParts) >= 2
+
+}
+
+func handleAdminCommandCases(m *Match, message string) {
+
+	var cardsToAdd []string
 	currentPlayer := m.CurrentPlayer().Player
 	msgParts := strings.Split(message, " ")
-	if len(msgParts) < 2 {
-		return
-	}
 
 	switch msgParts[0] {
+
+	// /add red 4 - add 4 fire cards to your hand
+	// /add n - add 1 nature card to your hand
+	// /add imageID 3 - add 3 copies of that specific card to your hand
+	// /add all 2 - add 2 cards from each civ to your hand
 	case "/add":
-		// Spawn card in hand
-		currentPlayer.SpawnCard(msgParts[1], HAND)
-		m.BroadcastState()
-		return
+
+		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
+
+		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, HAND, msgParts)
 
 	// /mana hand - will add all the cards in your hand to the manazone
 	// /mana red 4 - add 4 fire mana
 	// /mana n - add 1 nature mana
 	// /mana imageID 3 - add 3 mana of that specific card
 	case "/mana":
-		var manaToAdd string
-		switch msgParts[1] {
-		case "hand":
-			for _, c := range currentPlayer.hand {
-				currentPlayer.MoveCard(c.ID, HAND, MANAZONE, "cmd /mana")
-				m.Chat("Server", fmt.Sprintf("%s was moved to %s's mana zone by an admin command", c.Name, user.Username))
-			}
-		case "fire", "f", "red":
-			manaToAdd = "af3bc221-1cc2-4f58-83ea-2673ac2c66c5"
-		case "water", "w", "blue":
-			manaToAdd = "9781089f-1aa9-4a75-b106-35e9d431e31d"
-		case "light", "l", "yellow":
-			manaToAdd = "7b58e8c2-0b1e-4ef5-812f-e667c2092c73"
-		case "darkness", "d", "black":
-			manaToAdd = "e2b992ee-91a3-49d3-8228-7be60a0b9ec5"
-		case "nature", "n", "green":
-			manaToAdd = "1d72eb3e-5185-449a-a16f-391bd2338343"
-		default:
-			manaToAdd = msgParts[1]
-		}
 
-		if manaToAdd != "" {
-			count := 1
-			if len(msgParts) > 2 {
-				number, err := strconv.Atoi(msgParts[2])
-				if err == nil && number >= 1 {
-					count = number
-				}
-			}
+		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
 
-			for i := 0; i < count; i++ {
-				currentPlayer.SpawnCard(manaToAdd, MANAZONE)
-			}
-		}
-
-		m.BroadcastState()
+		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, MANAZONE, msgParts)
 
 		return
 
+	// /shield hand - will add all the cards in your hand to the shieldzone
+	// /shield red 4 - add 4 fire shields
+	// /shield n - add 1 nature shield
+	// /shield imageID 3 - add 3 shields of that specific card
 	case "/shield":
 
-		// Spawn shield
-		currentPlayer.SpawnCard(msgParts[1], SHIELDZONE)
-		m.BroadcastState()
+		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
+
+		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, SHIELDZONE, msgParts)
+
 		return
 
+	// /deck hand - will add all the cards in your hand to the deck
+	// /deck red 4 - add 4 fire cards to the deck
+	// /deck n - add 1 nature card to the deck
+	// /deck imageID 3 - add 3 copies of that specific card to the deck
 	case "/deck":
 
-		// Spawn card in deck
-		currentPlayer.SpawnCard(msgParts[1], DECK)
-		m.BroadcastState()
+		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
+
+		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, DECK, msgParts)
+
+		return
+
+	// /grave hand - will add all the cards in your hand to the graveyard
+	// /grave red 4 - add 4 fire cards to your graveyard
+	// /grave n - add 1 nature card to your graveyard
+	// /grave imageID 3 - add 3 copies of that specific card to your graveyard
+	case "/grave":
+
+		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
+
+		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, SHIELDZONE, msgParts)
+
 		return
 
 	}
+
+}
+
+func getCardsToAddFromGivenCommand(crtPlayer *Player, command string) []string {
+
+	var cardsToAdd []string
+
+	switch command {
+
+	case "hand":
+		for _, c := range crtPlayer.hand {
+			cardsToAdd = append(cardsToAdd, c.ID)
+		}
+	case "fire", "f", "red":
+		cardsToAdd = []string{"af3bc221-1cc2-4f58-83ea-2673ac2c66c5"}
+	case "water", "w", "blue":
+		cardsToAdd = []string{"9781089f-1aa9-4a75-b106-35e9d431e31d"}
+	case "light", "l", "yellow":
+		cardsToAdd = []string{"7b58e8c2-0b1e-4ef5-812f-e667c2092c73"}
+	case "darkness", "d", "black":
+		cardsToAdd = []string{"e2b992ee-91a3-49d3-8228-7be60a0b9ec5"}
+	case "nature", "n", "green":
+		cardsToAdd = []string{"1d72eb3e-5185-449a-a16f-391bd2338343"}
+	case "all", "fromAll", "fromall":
+		cardsToAdd =
+			[]string{
+				"af3bc221-1cc2-4f58-83ea-2673ac2c66c5",
+				"9781089f-1aa9-4a75-b106-35e9d431e31d",
+				"7b58e8c2-0b1e-4ef5-812f-e667c2092c73",
+				"e2b992ee-91a3-49d3-8228-7be60a0b9ec5",
+				"1d72eb3e-5185-449a-a16f-391bd2338343",
+			}
+	default:
+		cardsToAdd = []string{command}
+	}
+
+	return cardsToAdd
+
+}
+
+func spawnCardsToGivenZone(m *Match,
+	player *Player,
+	cardsToSpawn []string,
+	zone string,
+	commands []string) {
+
+	if len(cardsToSpawn) > 0 {
+		count := 1
+		if len(commands) > 2 && commands[1] != "hand" {
+			number, err := strconv.Atoi(commands[2])
+			if err == nil && number >= 1 {
+				count = number
+			}
+		}
+
+		for i := 0; i < len(cardsToSpawn); i++ {
+			for j := 0; j < count; j++ {
+				player.SpawnCard(cardsToSpawn[i], zone)
+			}
+		}
+	}
+
+	m.BroadcastState()
+
 }

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -1968,25 +1968,34 @@ func handleAdminCommandCases(m *Match, message string) {
 
 	switch msgParts[0] {
 
+	// /init all 5 - initialize all zones (hand, shield, mana, deck, graveyard)
+	//					with 5 cards from each civ (25 in total) for each zone
+	case "/init":
+
+		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
+
+		spawnCardsToGivenZones(m, currentPlayer, cardsToAdd, []string{HAND, DECK, SHIELDZONE, MANAZONE, GRAVEYARD}, msgParts)
+
 	// /add red 4 - add 4 fire cards to your hand
 	// /add n - add 1 nature card to your hand
 	// /add imageID 3 - add 3 copies of that specific card to your hand
-	// /add all 2 - add 2 cards from each civ to your hand
+	// /add all 5 - add 5 cards from each civ to your hand (25 in total)
 	case "/add":
 
 		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
 
-		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, HAND, msgParts)
+		spawnCardsToGivenZones(m, currentPlayer, cardsToAdd, []string{HAND}, msgParts)
 
 	// /mana hand - will add all the cards in your hand to the manazone
 	// /mana red 4 - add 4 fire mana
 	// /mana n - add 1 nature mana
 	// /mana imageID 3 - add 3 mana of that specific card
+	// /mana all 5 - add 5 mana from each civ to your hand (25 in total)
 	case "/mana":
 
 		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
 
-		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, MANAZONE, msgParts)
+		spawnCardsToGivenZones(m, currentPlayer, cardsToAdd, []string{MANAZONE}, msgParts)
 
 		return
 
@@ -1994,11 +2003,12 @@ func handleAdminCommandCases(m *Match, message string) {
 	// /shield red 4 - add 4 fire shields
 	// /shield n - add 1 nature shield
 	// /shield imageID 3 - add 3 shields of that specific card
+	// /shield all 5 - add 5 shields from each civ (25 in total)
 	case "/shield":
 
 		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
 
-		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, SHIELDZONE, msgParts)
+		spawnCardsToGivenZones(m, currentPlayer, cardsToAdd, []string{SHIELDZONE}, msgParts)
 
 		return
 
@@ -2006,11 +2016,12 @@ func handleAdminCommandCases(m *Match, message string) {
 	// /deck red 4 - add 4 fire cards to the deck
 	// /deck n - add 1 nature card to the deck
 	// /deck imageID 3 - add 3 copies of that specific card to the deck
+	// /deck all 5 - add 5 cards from each civ to the deck (25 in total)
 	case "/deck":
 
 		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
 
-		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, DECK, msgParts)
+		spawnCardsToGivenZones(m, currentPlayer, cardsToAdd, []string{DECK}, msgParts)
 
 		return
 
@@ -2018,11 +2029,12 @@ func handleAdminCommandCases(m *Match, message string) {
 	// /grave red 4 - add 4 fire cards to your graveyard
 	// /grave n - add 1 nature card to your graveyard
 	// /grave imageID 3 - add 3 copies of that specific card to your graveyard
+	// /grave all 5 - add 5 cards from each civ to your graveyard (25 in total)
 	case "/grave":
 
 		cardsToAdd = getCardsToAddFromGivenCommand(currentPlayer, msgParts[1])
 
-		spawnCardsToGivenZone(m, currentPlayer, cardsToAdd, SHIELDZONE, msgParts)
+		spawnCardsToGivenZones(m, currentPlayer, cardsToAdd, []string{GRAVEYARD}, msgParts)
 
 		return
 
@@ -2067,10 +2079,10 @@ func getCardsToAddFromGivenCommand(crtPlayer *Player, command string) []string {
 
 }
 
-func spawnCardsToGivenZone(m *Match,
+func spawnCardsToGivenZones(m *Match,
 	player *Player,
 	cardsToSpawn []string,
-	zone string,
+	zones []string,
 	commands []string) {
 
 	if len(cardsToSpawn) > 0 {
@@ -2082,9 +2094,11 @@ func spawnCardsToGivenZone(m *Match,
 			}
 		}
 
-		for i := 0; i < len(cardsToSpawn); i++ {
-			for j := 0; j < count; j++ {
-				player.SpawnCard(cardsToSpawn[i], zone)
+		for _, z := range zones {
+			for i := range cardsToSpawn {
+				for range count {
+					player.SpawnCard(cardsToSpawn[i], z)
+				}
 			}
 		}
 	}

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -1107,8 +1107,7 @@ func (m *Match) AttackPlayer(p *PlayerReference, cardID string) {
 	}
 
 	ctx := NewContext(m, &AttackPlayer{
-		CardID:   cardID,
-		Blockers: make([]*Card, 0),
+		CardID: cardID,
 	})
 
 	m.HandleFx(ctx)
@@ -1137,7 +1136,6 @@ func (m *Match) AttackCreature(p *PlayerReference, cardID string) {
 
 	ctx := NewContext(m, &AttackCreature{
 		CardID:              cardID,
-		Blockers:            make([]*Card, 0),
 		AttackableCreatures: make([]*Card, 0),
 	})
 

--- a/game/match/player.go
+++ b/game/match/player.go
@@ -550,17 +550,14 @@ func (p *Player) CanPlayCard(card *Card, mana []*Card) bool {
 	manaCost := card.ManaCost
 	for _, condition := range card.Conditions() {
 		if condition.ID == cnd.ReducedCost {
-			if condition.ID == cnd.ReducedCost {
-				manaCost -= condition.Val.(int)
-				if manaCost < 1 {
-					manaCost = 1
-				}
+			manaCost -= condition.Val.(int)
+			if manaCost < 1 {
+				manaCost = 1
 			}
+		}
 
-			if condition.ID == cnd.IncreasedCost {
-				manaCost += condition.Val.(int)
-			}
-
+		if condition.ID == cnd.IncreasedCost {
+			manaCost += condition.Val.(int)
 		}
 	}
 

--- a/game/match/player.go
+++ b/game/match/player.go
@@ -274,6 +274,8 @@ func (p *Player) SpawnCard(id string, zone string) {
 		p.ShieldMap[c.ID] = p.ShieldCounter
 	case DECK:
 		p.deck = append(p.deck, c)
+	case GRAVEYARD:
+		p.graveyard = append(p.graveyard, c)
 	default:
 		logrus.Warnf("Failed to create card with id %s - invalid zone", id)
 		return

--- a/game/match/player.go
+++ b/game/match/player.go
@@ -246,9 +246,9 @@ func (p *Player) DestroyDeck() {
 	p.deck = nil
 }
 
-// SpawnCard creates a new card from an id and adds it to the players hand
+// SpawnCard creates a new card from an id and adds it to the players' given zone
 // used for debugging and development
-func (p *Player) SpawnCard(id string, area string) {
+func (p *Player) SpawnCard(id string, zone string) {
 
 	p.mutex.Lock()
 
@@ -261,9 +261,9 @@ func (p *Player) SpawnCard(id string, area string) {
 		return
 	}
 
-	c.Zone = area
+	c.Zone = zone
 
-	switch area {
+	switch zone {
 	case HAND:
 		p.hand = append(p.hand, c)
 	case MANAZONE:
@@ -275,7 +275,7 @@ func (p *Player) SpawnCard(id string, area string) {
 	case DECK:
 		p.deck = append(p.deck, c)
 	default:
-		logrus.Warnf("Failed to create card with id %s - invalid area", id)
+		logrus.Warnf("Failed to create card with id %s - invalid zone", id)
 		return
 	}
 }

--- a/internal/concurrentdictionary.go
+++ b/internal/concurrentdictionary.go
@@ -1,6 +1,9 @@
 package internal
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
 type ConcurrentDictionary[T any] struct {
 	sync.RWMutex
@@ -65,7 +68,7 @@ func (d *ConcurrentDictionary[T]) Remove(key string) {
 		return
 	}
 
-	d.src = append(d.src[:toRemove], d.src[toRemove+1:]...)
+	d.src = slices.Delete(d.src, toRemove, toRemove+1)
 	delete(d.keyValStore, key)
 }
 

--- a/internal/concurrentdictionary.go
+++ b/internal/concurrentdictionary.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"slices"
 	"sync"
 )
 
@@ -68,7 +67,7 @@ func (d *ConcurrentDictionary[T]) Remove(key string) {
 		return
 	}
 
-	d.src = slices.Delete(d.src, toRemove, toRemove+1)
+	d.src = append(d.src[:toRemove], d.src[toRemove+1:]...)
 	delete(d.keyValStore, key)
 }
 

--- a/server/socket.go
+++ b/server/socket.go
@@ -136,12 +136,12 @@ func (s *Socket) handlePing() {
 			return
 		}
 
-		select {
-		case <-ticker.C:
+		for range ticker.C {
 			s.mutex.Lock()
 			s.conn.SetWriteDeadline(time.Now().Add(writeWait))
 			err := s.conn.WriteMessage(websocket.PingMessage, nil)
 			s.mutex.Unlock()
+
 			if err != nil {
 				if !s.closed && !s.lost {
 					s.conn.Close()
@@ -154,7 +154,7 @@ func (s *Socket) handlePing() {
 }
 
 // Send sends a struct v to the client
-func (s *Socket) Send(v interface{}) {
+func (s *Socket) Send(v any) {
 
 	if s.closed || s.lost {
 		return

--- a/server/socket.go
+++ b/server/socket.go
@@ -136,7 +136,8 @@ func (s *Socket) handlePing() {
 			return
 		}
 
-		for range ticker.C {
+		select {
+		case <-ticker.C:
 			s.mutex.Lock()
 			s.conn.SetWriteDeadline(time.Now().Add(writeWait))
 			err := s.conn.WriteMessage(websocket.PingMessage, nil)


### PR DESCRIPTION
Refactored fx.**AttackConfirmed** usages inside fx.Creature handle of AttackPlayer and AttackCreature, so fx.**WheneverThisAttacks** was removed (and all of the other helper functions that were introduced with WheneverThisAttacks).

Essentially, both AttackConfirmed and WheneverThisAttacks served the same purpose, to handle attacking effects that happened right after the attack was confirmed (i.e. player chooses what shield / what creature to attack and commits the attack, i.e. action is NOT cancellable anymore) as per DM rules.

Also, introduced a new "step" event, **SelectBlockers**, that serves as a helper step right before the opponent is prompted to select a blocker before the battle / shield brake to happen. This new "step" event is now the ONLY place in which the initialization of the blockers list is made. This is also used for cards with **blockers** **modifications** **effects** (conditional Blockers, conditional CantBeBlocked, or cards like Tropico) to hook into and **modify** the blockers list accordingly. NOTE: Blockers list has been removed from AttackPlayer and AttackCreature events.

Finally, I improved the **admin** **messages** **handler** with some **QoL** **additions** for **faster** **debugging** and initialization of the cards in the playzones. They reduce the number of commands one has to write in order to actually create a "playable" match context, i.e. populate different zones (hand, mana, shields, deck) very easily with a lot of different cards.

**P.S.** It is my first PR here, so please feel free to comment anything you think, I am eager to learn and to accept every kind of comment.

**P.S. 2**: Here is a non-exhaustive list of cards that I thought would be affected by the changes. I tested them and I marked those that I consider fine with "✅". 

TOEL VIZIER OF HOPE ✅
AMBER PIERCER ✅
SILVER AXE ✅
DARK TITAN MAGINN ✅
PLASMA CHASER ✅
HORRID WORM ✅
PSYSHROOM ✅
GAMIL ✅
SNIPER MOSQUITO ✅
EARTHSTOMP GIANT ✅
THREE-EYED DRAGONFLY ✅
BLOODWING MANTIS ✅

METALWING SKYTERROR ✅
STAINED GLASS ✅
WYN THE ORACLE ✅
CURIOUS EYE ✅
Armored Warrior Quelos ✅
MURAMASA, DUKE OF BLADES ✅
KING NEPTAS ✅
LE QUIST THE ORACLE ✅

DAIDALOS GENERAL OF FURY ✅
Geoshine Spectral Knight ✅
Necrodragon Galbazeek ✅

HEADLONG GIANT ✅
Tower Shell ✅
Stampeding Longhorn ✅
Xeno Mantis ✅
Masked Pomegranate ✅
Ultra Mantis, Scourge of Fate ✅
Clobber Totem ✅

King Nautilus ✅
King Benthos ✅
Sopian ✅
Legendary Bynor ✅
King Triumphant ✅
Aqua Rider ✅
Bex, the Oracle ✅
Siri, Glory Elemental ✅
Sparkle Flower ✅
Overload Cluster ✅
Gariel Elemental of Submeans ✅
Gregoria, Princess of War ✅
Creeping Plague ✅
Diamond Cutter ✅
Sieg Balicula, the Intense ✅
Gallia Zohl, Iron Guardian Q ✅
Full Defensor ✅