### PR TITLE
Fix La Byle, Seeker of the Winds effect

### DIFF
--- a/game/cards/dm05/mecha_thunder.go
+++ b/game/cards/dm05/mecha_thunder.go
@@ -33,12 +33,10 @@ func LaByleSeekerOfTheWinds(c *match.Card) {
 
 	c.Use(fx.Creature, fx.Blocker(), func(card *match.Card, ctx *match.Context) {
 
-		if event, ok := ctx.Event.(*match.CreatureDestroyed); ok {
-
-			if event.Source == card && event.Blocked {
+		if event, ok := ctx.Event.(*match.Battle); ok {
+			if event.Blocked && event.Defender == card {
 				card.Tapped = false
 			}
-
 		}
 
 	})


### PR DESCRIPTION
## 📝 Summary

La Byle bug, discovered by me in a random match. cc: @sindreslungaard

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- La Byle, Seeker of the Winds wrong implementation. Before, even if he attacked and was blocked, it still untapped himself after the battle, which is wrong. Copied implementation from Kuukai, which works correctly.

## 🔧 Other Changes

- 

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it