### PR TITLE
Fix Ra Vu attacking effect

### DIFF
--- a/game/cards/dm03/mecha_thunder.go
+++ b/game/cards/dm03/mecha_thunder.go
@@ -25,11 +25,11 @@ func RaVuSeekerOfLightning(c *match.Card) {
 			ctx.Match,
 			card.Player,
 			match.GRAVEYARD,
-			fmt.Sprintf("%s: You may return 1 spell from your graveyard to your hand", card.Name),
+			fmt.Sprintf("%s: You may return 1 light spell from your graveyard to your hand", card.Name),
 			1,
 			1,
 			true,
-			func(x *match.Card) bool { return x.HasCondition(cnd.Spell) },
+			func(x *match.Card) bool { return x.HasCondition(cnd.Spell) && x.Civ == civ.Light },
 			false,
 		).Map(func(x *match.Card) {
 			x.Player.MoveCard(x.ID, match.GRAVEYARD, match.HAND, card.ID)


### PR DESCRIPTION
## 📝 Summary

Fixed Ra Vu attacking effect.

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Ra Vu attacking effect. Now it only selects lights spells from graveyard.

## 🔧 Other Changes

- 

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it