### PR TITLE
Fix Zeppelin Crawler and Kelp Candle effect. Now correctly triggers o…

### DIFF
--- a/game/cards/dm09/cyber_virus.go
+++ b/game/cards/dm09/cyber_virus.go
@@ -34,15 +34,5 @@ func KelpCandle(c *match.Card) {
 	c.ManaRequirement = []string{civ.Water}
 
 	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers,
-		func(card *match.Card, ctx *match.Context) {
-			if event, ok := ctx.Event.(*match.Battle); ok {
-				if !event.Blocked || event.Defender != card {
-					return
-				}
-
-				ctx.ScheduleAfter(func() {
-					fx.LookTop4Put1IntoHandReorderRestOnBottomDeck(card, ctx)
-				})
-			}
-		})
+		fx.When(fx.Blocks, fx.LookTop4Put1IntoHandReorderRestOnBottomDeck))
 }

--- a/game/cards/dm09/earth_eater.go
+++ b/game/cards/dm09/earth_eater.go
@@ -18,6 +18,6 @@ func ZeppelinCrawler(c *match.Card) {
 	c.ManaRequirement = []string{civ.Water}
 
 	c.Use(fx.Creature, fx.Blocker(), fx.CantAttackCreatures, fx.CantAttackPlayers,
-		fx.LookTop4Put1IntoHandReorderRestOnBottomDeck)
+		fx.When(fx.Blocks, fx.LookTop4Put1IntoHandReorderRestOnBottomDeck))
 
 }

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -169,6 +169,16 @@ func BinaryQuestion(p *match.Player, m *match.Match, text string) bool {
 }
 
 func OrderCards(p *match.Player, m *match.Match, cards []*match.Card, text string) []string {
+	var cardsIds []string
+
+	if len(cards) < 2 {
+		for _, c := range cards {
+			cardsIds = append(cardsIds, c.ID)
+		}
+
+		return cardsIds
+	}
+
 	m.NewOrderAction(p, cards, text)
 	defer m.CloseAction(p)
 
@@ -177,7 +187,6 @@ func OrderCards(p *match.Player, m *match.Match, cards []*match.Card, text strin
 		defer m.EndWait(m.Opponent(p))
 	}
 
-	var cardsIds []string
 	for _, c := range cards {
 		cardsIds = append(cardsIds, c.ID)
 	}
@@ -928,9 +937,18 @@ func IsTapped(card *match.Card, ctx *match.Context) bool {
 	return false
 }
 
+// Blocked checks if the card was blocked
 func Blocked(card *match.Card, ctx *match.Context) bool {
 	if event, ok := ctx.Event.(*match.Battle); ok {
 		return event.Blocked && event.Attacker == card
+	}
+	return false
+}
+
+// Blocks checks if the card blocks another creature
+func Blocks(card *match.Card, ctx *match.Context) bool {
+	if event, ok := ctx.Event.(*match.Battle); ok {
+		return event.Blocked && event.Defender == card
 	}
 	return false
 }
@@ -1170,7 +1188,7 @@ func LookTop4Put1IntoHandReorderRestOnBottomDeck(card *match.Card, ctx *match.Co
 		false,
 	).Map(func(x *match.Card) {
 		card.Player.MoveCard(x.ID, match.DECK, match.HAND, card.ID)
-		ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was put into %s's hand from his deck by %s's effect.", x.Name, card.Player.Username(), card.Name))
+		ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("A card was put into %s's hand from his deck by %s's effect.", card.Player.Username(), card.Name))
 
 		restOfCards := top4CardsDeck[:0]
 		for _, card := range top4CardsDeck {
@@ -1188,6 +1206,7 @@ func LookTop4Put1IntoHandReorderRestOnBottomDeck(card *match.Card, ctx *match.Co
 
 		if len(orderedCardIds) == len(restOfCards) {
 			card.Player.ReorderCardsOnBottomDeck(restOfCards, orderedCardIds)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%v cards were reordered at the bottom of %s's deck by %s's effect.", len(orderedCardIds), card.Player.Username(), card.Name))
 		}
 
 	})

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -170,6 +170,7 @@ func BinaryQuestion(p *match.Player, m *match.Match, text string) bool {
 
 func OrderCards(p *match.Player, m *match.Match, cards []*match.Card, text string) []string {
 	var cardsIds []string
+	cardsIds = make([]string, 0)
 
 	if len(cards) < 2 {
 		for _, c := range cards {


### PR DESCRIPTION
Fix Zeppelin Crawler and Kelp Candle effect. Now correctly triggers only when the cards blocks.

## 📝 Summary

Provide a brief summary of your changes and the motivation behind them.

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Zeppelin Crawler and Kelp Candle effects were incorrectly triggered at the start of the game.
- Fixed those by correctly handling the effect, only when those cards are blocking another creature.

## 🔧 Other Changes

- 

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it