### PR TITLE
Quality of life fx.SelectFilter improvement

### DIFF
--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -292,6 +292,12 @@ func SelectFilter(p *match.Player, m *match.Match, containerOwner *match.Player,
 		max = filteredLength
 	}
 
+	// Bypass the selection pop-up if action is NOT cancellable and the selection is unambiguous, i.e. filtered cards length == min == max
+	// i.e. user doesn't have a choice
+	if !cancellable && min == max && filteredLength == min {
+		return filtered
+	}
+
 	if !m.IsPlayerTurn(p) {
 		m.Wait(m.Opponent(p), "Waiting for your opponent to make an action")
 		defer m.EndWait(m.Opponent(p))


### PR DESCRIPTION
Bypass the selection pop-up if action is NOT cancellable and the selection is unambiguous, (i.e. filtered cards length == min == max).

In other words, if user doesn't have a choice, the pop-up doesnt appear anymore and the cards are automatically selected.

## 📝 Summary

Provide a brief summary of your changes and the motivation behind them.

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- 

## 🔧 Other Changes

- Improved the game speed by speculating an edge case that resulted in an unnecessary select pop-up on fx.SelectFilter.
- Basically, when the container cards for selection has length equal or less to min and max for that selection, and the action is NOT cancellable, it bypasses the selection pop-up and only resolves the effect of the selection.
- Tested with Cranium Clamp when opponent has only 1, respectively only 2 cards in hand. Pop-up is skipped entirely.

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it