### PR TITLE
Fix for SpiralGrass Untap effect

### DIFF
--- a/game/cards/dm02/starlight_tree.go
+++ b/game/cards/dm02/starlight_tree.go
@@ -18,15 +18,16 @@ func SpiralGrass(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Creature, fx.Blocker(), func(card *match.Card, ctx *match.Context) {
-
-		if event, ok := ctx.Event.(*match.CreatureDestroyed); ok {
-
-			if event.Source == card && event.Blocked {
-				card.Tapped = false
+		if event, ok := ctx.Event.(*match.Battle); ok {
+			if event.Defender == card && event.Blocked {
+				ctx.ScheduleAfter(func() {
+					if card.Zone == match.BATTLEZONE {
+						card.Tapped = false
+						ctx.Match.BroadcastState()
+					}
+				})
 			}
-
 		}
-
 	})
 
 }


### PR DESCRIPTION
## 📝 Summary

Fix for Spiral Grass Untap effect wrongly being fired on CreatureDestroyed, thus wrongly interffering with cards like Mighty Shouter.

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Spiral Grass untap effect fixed.

## 🔧 Other Changes

- 

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it