### PR TITLE
Fix Lunar Charger ApplyPersistentEffect wrongly referring to outer ctx, not inner ctx2 parameter.

### DIFF
--- a/game/cards/dm01/spells.go
+++ b/game/cards/dm01/spells.go
@@ -111,7 +111,7 @@ func CreepingPlague(c *match.Card) {
 				}
 
 				event.Attacker.AddCondition(cnd.Slayer, nil, card.ID)
-				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was given \"Slayer\" by %s", event.Attacker.Name, card.Name))
+				ctx2.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was given \"Slayer\" by %s", event.Attacker.Name, card.Name))
 
 			}
 

--- a/game/cards/dm04/guardian.go
+++ b/game/cards/dm04/guardian.go
@@ -37,23 +37,16 @@ func MistRiasSonicGuardian(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if card.Zone != match.BATTLEZONE {
-
 				exit()
 				return
 			}
 
 			if fx.AnotherCreatureSummoned(card, ctx2) {
-
 				fx.MayDraw1(card, ctx2)
-
 			}
-
 		})
-
 	}))
 
 }

--- a/game/cards/dm04/hedrian.go
+++ b/game/cards/dm04/hedrian.go
@@ -31,24 +31,16 @@ func MongrelMan(c *match.Card) {
 	c.ManaRequirement = []string{civ.Darkness}
 
 	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if card.Zone != match.BATTLEZONE {
-
 				exit()
 				return
-
 			}
 
 			if fx.AnotherCreatureDestroyed(card, ctx2) {
-
 				fx.MayDraw1(card, ctx2)
-
 			}
-
 		})
-
 	}))
 
 }

--- a/game/cards/dm04/mecha_thunder.go
+++ b/game/cards/dm04/mecha_thunder.go
@@ -40,9 +40,7 @@ func ReBilSeekerOfArchery(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Creature, fx.Doublebreaker, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			getLightCreatures(card, ctx2).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.PowerAmplifier, 2000, card.ID)
 			})
@@ -53,7 +51,6 @@ func ReBilSeekerOfArchery(c *match.Card) {
 				})
 				exit()
 			}
-
 		})
 	}))
 }

--- a/game/cards/dm04/spells.go
+++ b/game/cards/dm04/spells.go
@@ -17,9 +17,7 @@ func FullDefensor(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			// on all events, add blocker to our creatures
 			fx.Find(
 				card.Player,
@@ -40,9 +38,7 @@ func FullDefensor(c *match.Card) {
 
 				exit()
 			}
-
 		})
-
 	}))
 }
 
@@ -384,7 +380,6 @@ func WhiskingWhirlwind(c *match.Card) {
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if _, ok := ctx2.Event.(*match.EndOfTurnStep); ok {
 				fx.Find(
 					card.Player,
@@ -392,12 +387,11 @@ func WhiskingWhirlwind(c *match.Card) {
 				).Map(func(x *match.Card) {
 					if x.Tapped {
 						x.Tapped = false
-						ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was untapped by %s's effect", x.Name, card.Name))
+						ctx2.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was untapped by %s's effect", x.Name, card.Name))
 					}
 				})
 				exit()
 			}
-
 		})
 	}))
 }

--- a/game/cards/dm05/armored_wyvern.go
+++ b/game/cards/dm05/armored_wyvern.go
@@ -33,11 +33,8 @@ func BladerushSkyterrorQ(c *match.Card) {
 	c.ManaRequirement = []string{civ.Fire}
 
 	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if card.Zone != match.BATTLEZONE {
-
 				fx.FindFilter(
 					card.Player,
 					match.BATTLEZONE,
@@ -48,7 +45,6 @@ func BladerushSkyterrorQ(c *match.Card) {
 
 				exit()
 				return
-
 			}
 
 			fx.FindFilter(
@@ -58,9 +54,7 @@ func BladerushSkyterrorQ(c *match.Card) {
 			).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.DoubleBreaker, true, card.ID)
 			})
-
 		})
-
 	}))
 
 }

--- a/game/cards/dm05/chimera.go
+++ b/game/cards/dm05/chimera.go
@@ -65,9 +65,7 @@ func GigalingQ(c *match.Card) {
 			).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.Slayer, true, card.ID)
 			})
-
 		})
-
 	}))
 
 }

--- a/game/cards/dm05/fish.go
+++ b/game/cards/dm05/fish.go
@@ -33,11 +33,8 @@ func SpikestrikeIchthysQ(c *match.Card) {
 	c.ManaRequirement = []string{civ.Water}
 
 	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if card.Zone != match.BATTLEZONE {
-
 				fx.FindFilter(
 					card.Player,
 					match.BATTLEZONE,
@@ -48,7 +45,6 @@ func SpikestrikeIchthysQ(c *match.Card) {
 
 				exit()
 				return
-
 			}
 
 			fx.FindFilter(
@@ -58,9 +54,7 @@ func SpikestrikeIchthysQ(c *match.Card) {
 			).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.CantBeBlocked, true, card.ID)
 			})
-
 		})
-
 	}))
 
 }

--- a/game/cards/dm05/guardian.go
+++ b/game/cards/dm05/guardian.go
@@ -46,11 +46,8 @@ func GalliaZohlIronGuardianQ(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if card.Zone != match.BATTLEZONE {
-
 				fx.FindFilter(
 					card.Player,
 					match.BATTLEZONE,
@@ -61,7 +58,6 @@ func GalliaZohlIronGuardianQ(c *match.Card) {
 
 				exit()
 				return
-
 			}
 
 			fx.FindFilter(
@@ -71,9 +67,7 @@ func GalliaZohlIronGuardianQ(c *match.Card) {
 			).Map(func(x *match.Card) {
 				fx.ForceBlocker(x, ctx2, card.ID)
 			})
-
 		})
-
 	}))
 
 }

--- a/game/cards/dm05/horned_beast.go
+++ b/game/cards/dm05/horned_beast.go
@@ -19,11 +19,8 @@ func SmashHornQ(c *match.Card) {
 	c.ManaRequirement = []string{civ.Nature}
 
 	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if card.Zone != match.BATTLEZONE {
-
 				fx.FindFilter(
 					card.Player,
 					match.BATTLEZONE,
@@ -34,7 +31,6 @@ func SmashHornQ(c *match.Card) {
 
 				exit()
 				return
-
 			}
 
 			fx.FindFilter(
@@ -44,9 +40,7 @@ func SmashHornQ(c *match.Card) {
 			).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.PowerAmplifier, 1000, card.ID)
 			})
-
 		})
-
 	}))
 
 }

--- a/game/cards/dm05/rock_beast.go
+++ b/game/cards/dm05/rock_beast.go
@@ -19,11 +19,8 @@ func BlazosaurQ(c *match.Card) {
 	c.ManaRequirement = []string{civ.Fire}
 
 	c.Use(fx.Creature, fx.Survivor, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if card.Zone != match.BATTLEZONE {
-
 				fx.FindFilter(
 					card.Player,
 					match.BATTLEZONE,
@@ -34,7 +31,6 @@ func BlazosaurQ(c *match.Card) {
 
 				exit()
 				return
-
 			}
 
 			fx.FindFilter(
@@ -44,9 +40,7 @@ func BlazosaurQ(c *match.Card) {
 			).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.PowerAttacker, 1000, card.ID)
 			})
-
 		})
-
 	}))
 
 }

--- a/game/cards/dm05/spells.go
+++ b/game/cards/dm05/spells.go
@@ -133,9 +133,7 @@ func SlimeVeil(c *match.Card) {
 	c.ManaRequirement = []string{civ.Darkness}
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			// remove persistent effect on start of next turn
 			if _, ok := ctx2.Event.(*match.StartOfTurnStep); ok && ctx2.Match.IsPlayerTurn(card.Player) {
 				exit()
@@ -147,13 +145,9 @@ func SlimeVeil(c *match.Card) {
 				ctx2.Match.Opponent(card.Player),
 				match.BATTLEZONE,
 			).Map(func(c *match.Card) {
-
 				if _, ok := ctx2.Event.(*match.EndTurnEvent); ok && c.Zone == match.BATTLEZONE {
-
 					if ctx2.Match.IsPlayerTurn(c.Player) && !fx.HasSummoningSickness(c) && !c.Tapped {
-
 						if c.HasCondition(cnd.CantAttackPlayers) {
-
 							if c.HasCondition(cnd.CantAttackCreatures) {
 								return
 							}
@@ -166,20 +160,14 @@ func SlimeVeil(c *match.Card) {
 							if len(attackableCreatures) == 0 {
 								return
 							}
-
 						}
 
 						ctx2.Match.WarnPlayer(c.Player, fmt.Sprintf("%s must attack before you can end your turn", c.Name))
 						ctx2.InterruptFlow()
-
 					}
-
 				}
-
 			})
-
 		})
-
 	}))
 }
 

--- a/game/cards/dm06/armorloid.go
+++ b/game/cards/dm06/armorloid.go
@@ -44,7 +44,6 @@ func ArmoredScoutGestuchar(c *match.Card) {
 	c.ManaRequirement = []string{civ.Fire}
 
 	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 			// Remove the conditions and exit the persistent effect when the card is no longer in the battle zone
 			if card.Zone != match.BATTLEZONE {

--- a/game/cards/dm06/ghost.go
+++ b/game/cards/dm06/ghost.go
@@ -19,11 +19,8 @@ func FrostSpecterShadowOfAge(c *match.Card) {
 	c.ManaRequirement = []string{civ.Darkness}
 
 	c.Use(fx.Creature, fx.Evolution, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if card.Zone != match.BATTLEZONE {
-
 				// remove cards with current buffs
 				getGhostCreatures(card).Map(func(x *match.Card) {
 					x.RemoveConditionBySource(card.ID)
@@ -31,21 +28,17 @@ func FrostSpecterShadowOfAge(c *match.Card) {
 
 				exit()
 				return
-
 			}
 
 			getGhostCreatures(card).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.Slayer, true, card.ID)
 			})
-
 		})
-
 	}))
 
 }
 
 func getGhostCreatures(card *match.Card) fx.CardCollection {
-
 	ghostCreatures := fx.FindFilter(
 		card.Player,
 		match.BATTLEZONE,

--- a/game/cards/dm07/mecha_thunder.go
+++ b/game/cards/dm07/mecha_thunder.go
@@ -18,7 +18,6 @@ func GandarSeekerofExplosions(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if _, ok := ctx2.Event.(*match.EndOfTurnStep); ok {
 				fx.Find(
 					card.Player,
@@ -31,7 +30,6 @@ func GandarSeekerofExplosions(c *match.Card) {
 				})
 				exit()
 			}
-
 		})
 	}
 

--- a/game/cards/dm07/mystery_totem.go
+++ b/game/cards/dm07/mystery_totem.go
@@ -31,9 +31,7 @@ func SpinningTotem(c *match.Card) {
 	c.ManaRequirement = []string{civ.Nature}
 	c.TapAbility = func(card *match.Card, ctx *match.Context) {
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if event, ok := ctx2.Event.(*match.Battle); ok {
-
 				if !event.Blocked || event.Attacker.Player != card.Player {
 					return
 				}
@@ -50,7 +48,6 @@ func SpinningTotem(c *match.Card) {
 			if ok {
 				exit()
 			}
-
 		})
 	}
 

--- a/game/cards/dm07/spells.go
+++ b/game/cards/dm07/spells.go
@@ -139,9 +139,7 @@ func FruitOfEternity(c *match.Card) {
 	c.ManaRequirement = []string{civ.Nature}
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if event, ok := ctx2.Event.(*match.CreatureDestroyed); ok && event.Card.Player == card.Player {
 				ctx2.InterruptFlow()
 				card.Player.MoveCard(event.Card.ID, match.BATTLEZONE, match.MANAZONE, card.ID)
@@ -155,6 +153,7 @@ func FruitOfEternity(c *match.Card) {
 			}
 		})
 	}))
+
 }
 
 func VacuumGel(c *match.Card) {
@@ -192,7 +191,6 @@ func MiraclePortal(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
-
 		fx.Select(
 			card.Player,
 			ctx.Match,
@@ -212,14 +210,14 @@ func MiraclePortal(c *match.Card) {
 				c.AddCondition(cnd.CantBeBlocked, nil, card)
 
 				// remove persistent effect when turn ends
-				_, ok := ctx2.Event.(*match.EndStep)
+				_, ok := ctx2.Event.(*match.EndOfTurnStep)
 				if ok {
 					exit()
 				}
 			})
 		})
-
 	}))
+
 }
 
 func VenomCharger(c *match.Card) {

--- a/game/cards/dm08/dark_lord.go
+++ b/game/cards/dm08/dark_lord.go
@@ -29,7 +29,7 @@ func MegariaEmpressOfDread(c *match.Card) {
 				})
 
 				fx.Find(
-					ctx.Match.Opponent(card.Player),
+					ctx2.Match.Opponent(card.Player),
 					match.BATTLEZONE,
 				).Map(func(x *match.Card) {
 					x.RemoveConditionBySource(card.ID)
@@ -47,7 +47,7 @@ func MegariaEmpressOfDread(c *match.Card) {
 			})
 
 			fx.Find(
-				ctx.Match.Opponent(card.Player),
+				ctx2.Match.Opponent(card.Player),
 				match.BATTLEZONE,
 			).Map(func(x *match.Card) {
 				x.AddUniqueSourceCondition(cnd.Slayer, true, card.ID)

--- a/game/cards/dm08/snow_faerie.go
+++ b/game/cards/dm08/snow_faerie.go
@@ -29,7 +29,6 @@ func KachuaKeeperOfTheIcegate(c *match.Card) {
 // Bazagazeal case: you should be able to choose from this creature's effect or
 // the card itself's effect (Bazagazeal)
 func kachuaKeeperOfTheIcegateTapAbility(card *match.Card, ctx *match.Context) {
-
 	// Search your deck. You MAY take a Dragon from your deck
 	fx.SelectFilter(
 		card.Player,
@@ -70,5 +69,4 @@ func kachuaKeeperOfTheIcegateTapAbility(card *match.Card, ctx *match.Context) {
 		// then shuffle deck
 		fx.ShuffleDeck(card, ctx, false)
 	})
-
 }

--- a/game/cards/dm08/spells.go
+++ b/game/cards/dm08/spells.go
@@ -110,7 +110,6 @@ func LaserWhip(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
-
 		fx.Select(
 			card.Player,
 			ctx.Match,
@@ -152,8 +151,8 @@ func LaserWhip(c *match.Card) {
 				})
 			})
 		})
-
 	}))
+
 }
 
 // LunarCharger ...
@@ -165,7 +164,6 @@ func LunarCharger(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Spell, fx.Charger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
-
 		fx.Select(
 			card.Player,
 			ctx.Match,
@@ -197,8 +195,8 @@ func LunarCharger(c *match.Card) {
 				}
 			})
 		})
-
 	}))
+
 }
 
 // RootCharger ...
@@ -211,7 +209,6 @@ func RootCharger(c *match.Card) {
 
 	c.Use(fx.Spell, fx.Charger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if event, ok := ctx2.Event.(*match.CreatureDestroyed); ok {
 				if event.Card.Player == card.Player {
 					card.Player.MoveCard(event.Card.ID, match.BATTLEZONE, match.MANAZONE, card.ID)
@@ -224,9 +221,9 @@ func RootCharger(c *match.Card) {
 					exit()
 				})
 			}
-
 		})
 	}))
+
 }
 
 // MarineScramble ...
@@ -239,7 +236,6 @@ func MarineScramble(c *match.Card) {
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			creatures := fx.Find(card.Player, match.BATTLEZONE)
 
 			if _, ok := ctx2.Event.(*match.EndOfTurnStep); ok {

--- a/game/cards/dm08/volcano_dragon.go
+++ b/game/cards/dm08/volcano_dragon.go
@@ -39,7 +39,6 @@ func MagmadragonJagalzor(c *match.Card) {
 		fx.When(fx.EndOfMyTurn, func(card *match.Card, ctx *match.Context) { turboRush = false }),
 		fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 			ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 				if card.Zone != match.BATTLEZONE {
 					fx.Find(
 						card.Player,
@@ -55,7 +54,6 @@ func MagmadragonJagalzor(c *match.Card) {
 				if turboRush {
 					fx.Find(card.Player, match.BATTLEZONE).Map(func(x *match.Card) { x.AddUniqueSourceCondition(cnd.SpeedAttacker, true, card.ID) })
 				}
-
 			})
 		}),
 	)

--- a/game/cards/dm09/armorloid.go
+++ b/game/cards/dm09/armorloid.go
@@ -18,9 +18,7 @@ func SimianWarriorGrash(c *match.Card) {
 	c.ManaRequirement = []string{civ.Fire}
 
 	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
-
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 			if card.Zone != match.BATTLEZONE {
 
 				exit()
@@ -31,9 +29,7 @@ func SimianWarriorGrash(c *match.Card) {
 			if event, ok := ctx2.Event.(*match.CreatureDestroyed); ok && event.Card.Player == c.Player && event.Card.HasFamily(family.Armorloid) {
 				fx.OpponentChoosesManaBurn(card, ctx2)
 			}
-
 		})
-
 	}))
 
 }

--- a/game/cards/dm09/mecha_del_sol.go
+++ b/game/cards/dm09/mecha_del_sol.go
@@ -46,7 +46,7 @@ func PetrovaChannelerOfSuns(c *match.Card) {
 						})
 
 						fx.FindFilter(
-							ctx.Match.Opponent(card.Player),
+							ctx2.Match.Opponent(card.Player),
 							match.BATTLEZONE,
 							func(x *match.Card) bool {
 								return x.HasFamily(chosenFamily)
@@ -55,7 +55,7 @@ func PetrovaChannelerOfSuns(c *match.Card) {
 							x.RemoveConditionBySource(card.ID)
 						})
 
-						ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("All creatures in the battlezone of race %s NO more have +4000 power", chosenFamily))
+						ctx2.Match.ReportActionInChat(card.Player, fmt.Sprintf("All creatures in the battlezone of race %s NO more have +4000 power", chosenFamily))
 
 						exit()
 						return
@@ -72,7 +72,7 @@ func PetrovaChannelerOfSuns(c *match.Card) {
 					})
 
 					fx.FindFilter(
-						ctx.Match.Opponent(card.Player),
+						ctx2.Match.Opponent(card.Player),
 						match.BATTLEZONE,
 						func(x *match.Card) bool {
 							return x.HasFamily(chosenFamily)

--- a/game/fx/common_effects.go
+++ b/game/fx/common_effects.go
@@ -93,7 +93,6 @@ func BlockerWhenNoShields(card *match.Card, ctx *match.Context) {
 
 func HaveSelfConditionsWhenNoShields(card *match.Card, ctx *match.Context, conditions []*match.Condition) {
 	ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
-
 		notInTheBZ := card.Zone != match.BATTLEZONE
 		if notInTheBZ || IHaveShields(card) {
 			for _, cond := range conditions {
@@ -115,7 +114,6 @@ func HaveSelfConditionsWhenNoShields(card *match.Card, ctx *match.Context, condi
 				}
 			}
 		}
-
 	})
 }
 


### PR DESCRIPTION
## 📝 Summary

Fix Lunar Charger ApplyPersistentEffect wrongly referring to outer ctx, not inner ctx2 parameter.

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- 

## 🔧 Other Changes

- Lunar Charger fixed,
- Cleaned up all other references to ApplyPersistentEffect that were not using inner ctx2 parameter, for consistency.

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it