### PR TITLE
Fix Bat Doctor Shadow of Undeath filter inside its effect

### DIFF
--- a/game/cards/dm09/ghost.go
+++ b/game/cards/dm09/ghost.go
@@ -2,6 +2,7 @@ package dm09
 
 import (
 	"duel-masters/game/civ"
+	"duel-masters/game/cnd"
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
@@ -30,7 +31,7 @@ func BatDoctorShadowOfUndeath(c *match.Card) {
 				1,
 				true,
 				func(x *match.Card) bool {
-					return x.ID != card.ID
+					return x.ID != card.ID && x.HasCondition(cnd.Creature)
 				},
 				false,
 			).Map(func(x *match.Card) {


### PR DESCRIPTION
## 📝 Summary

Fix Bat Doctor Shadow of Undeath filter inside its effect

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Bat Doctor Shadow of Undeath wrongly retrieved both creatures and spells from graveyard.
- Now it only retrieves creatures.

## 🔧 Other Changes

- 

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it