### PR TITLE
Refactor Carbonite Scarab to correctly use WheneverThisAttackPlayerAndBecomesBlocked

### DIFF
--- a/game/cards/dm05/giant.go
+++ b/game/cards/dm05/giant.go
@@ -17,7 +17,7 @@ func AvalancheGiant(c *match.Card) {
 	c.ManaCost = 6
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.CantAttackCreatures, fx.When(fx.Blocked, fx.DestoryOpShield))
+	c.Use(fx.Creature, fx.Doublebreaker, fx.CantAttackCreatures, fx.When(fx.Blocked, fx.DestroyOpShield))
 
 }
 

--- a/game/cards/dm06/giant_insect.go
+++ b/game/cards/dm06/giant_insect.go
@@ -28,7 +28,7 @@ func SplinterclawWasp(c *match.Card) {
 	c.ManaCost = 7
 	c.ManaRequirement = []string{civ.Nature}
 
-	c.Use(fx.Creature, fx.Doublebreaker, fx.PowerAttacker3000, fx.When(fx.Blocked, fx.DestoryOpShield))
+	c.Use(fx.Creature, fx.Doublebreaker, fx.PowerAttacker3000, fx.When(fx.Blocked, fx.DestroyOpShield))
 }
 
 func TrenchScarab(c *match.Card) {

--- a/game/cards/dm07/mystery_totem.go
+++ b/game/cards/dm07/mystery_totem.go
@@ -42,7 +42,7 @@ func SpinningTotem(c *match.Card) {
 					return
 				}
 
-				fx.DestoryOpShield(card, ctx2)
+				fx.DestroyOpShield(card, ctx2)
 			}
 
 			// remove persistent effect when turn ends

--- a/game/cards/dm08/giant_insects.go
+++ b/game/cards/dm08/giant_insects.go
@@ -19,31 +19,15 @@ func CarboniteScarab(c *match.Card) {
 
 	turboRush := false
 
-	attackingOpponent := false
-
 	c.Use(
 		fx.Creature,
 		fx.When(fx.TurboRushCondition, func(card *match.Card, ctx *match.Context) { turboRush = true }),
-		func(card *match.Card, ctx *match.Context) {
-			// NOTE: currently bugged as attack can be cancelled
-			// need to refactor Battle so that AttackConfirmed can tell if a creature was blocked while attacking a player
-			if event, ok := ctx.Event.(*match.AttackPlayer); ok && event.CardID == c.ID {
-				attackingOpponent = true
-			}
-		},
 		fx.When(fx.EndOfMyTurn, func(card *match.Card, ctx *match.Context) {
 			turboRush = false
 		}),
-		fx.When(func(card *match.Card, ctx *match.Context) bool { return turboRush }, func(card *match.Card, ctx *match.Context) {
-			if event, ok := ctx.Event.(*match.Battle); ok {
-
-				if event.Attacker == c && event.Blocked && attackingOpponent {
-					fx.DestoryOpShield(card, ctx)
-					attackingOpponent = false
-				}
-
-			}
-
-		}))
+		fx.WhenAll([]func(*match.Card, *match.Context) bool{func(card *match.Card, ctx *match.Context) bool { return turboRush }, fx.WheneverThisAttacksPlayerAndBecomesBlocked},
+			func(card *match.Card, ctx *match.Context) {
+				fx.DestroyOpShield(card, ctx)
+			}))
 
 }

--- a/game/fx/common_effects.go
+++ b/game/fx/common_effects.go
@@ -167,7 +167,7 @@ func RotateShields(card *match.Card, ctx *match.Context, max int) {
 
 }
 
-func DestoryOpShield(card *match.Card, ctx *match.Context) {
+func DestroyOpShield(card *match.Card, ctx *match.Context) {
 	opponent := ctx.Match.Opponent(card.Player)
 
 	ctx.Match.BreakShields(SelectBackside(

--- a/game/fx/creature.go
+++ b/game/fx/creature.go
@@ -377,7 +377,7 @@ func Creature(card *match.Card, ctx *match.Context) {
 					ctx.Match.EndWait(card.Player)
 					ctx.Match.CloseAction(opponent)
 
-					ctx.Match.Battle(card, c, true)
+					ctx.Match.Battle(card, c, true, true)
 
 					break
 
@@ -449,7 +449,7 @@ func Creature(card *match.Card, ctx *match.Context) {
 					ctx.Match.EndWait(card.Player)
 					ctx.Match.CloseAction(opponent)
 
-					ctx.Match.Battle(card, blocker, true)
+					ctx.Match.Battle(card, blocker, true, false)
 
 					return
 
@@ -457,7 +457,7 @@ func Creature(card *match.Card, ctx *match.Context) {
 
 			}
 
-			ctx.Match.Battle(card, attackedCard, false)
+			ctx.Match.Battle(card, attackedCard, false, false)
 
 		}
 	}

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -962,7 +962,7 @@ func WheneverThisAttacksPlayerAndIsntBlocked(card *match.Card, ctx *match.Contex
 	return false
 }
 
-func WheneverThisAttackPlayerAndBecomesBlocked(card *match.Card, ctx *match.Context) bool {
+func WheneverThisAttacksPlayerAndBecomesBlocked(card *match.Card, ctx *match.Context) bool {
 	if event, ok := ctx.Event.(*match.Battle); ok &&
 		event.FromAttackPlayer &&
 		event.Attacker == card &&

--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -962,6 +962,16 @@ func WheneverThisAttacksPlayerAndIsntBlocked(card *match.Card, ctx *match.Contex
 	return false
 }
 
+func WheneverThisAttackPlayerAndBecomesBlocked(card *match.Card, ctx *match.Context) bool {
+	if event, ok := ctx.Event.(*match.Battle); ok &&
+		event.FromAttackPlayer &&
+		event.Attacker == card &&
+		event.Blocked {
+		return true
+	}
+	return false
+}
+
 func CanBeSummoned(player *match.Player, card *match.Card) bool {
 	if !card.HasCondition(cnd.Creature) {
 		return false

--- a/game/match/events.go
+++ b/game/match/events.go
@@ -116,11 +116,12 @@ type Block struct {
 
 // Battle is fired when two creatures are fighting, i.e. from attacking a creature or blocking an attack
 type Battle struct {
-	Attacker      *Card
-	AttackerPower int
-	Defender      *Card
-	DefenderPower int
-	Blocked       bool
+	Attacker         *Card
+	AttackerPower    int
+	Defender         *Card
+	DefenderPower    int
+	Blocked          bool
+	FromAttackPlayer bool
 }
 
 type CreatureDestroyedContext int

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -214,12 +214,12 @@ func (m *Match) getPlayerMatchId(player *Player) byte {
 }
 
 // Battle handles a battle between two creatures
-func (m *Match) Battle(attacker *Card, defender *Card, blocked bool) {
+func (m *Match) Battle(attacker *Card, defender *Card, blocked bool, fromAttackPlayer bool) {
 
 	attackerPower := m.GetPower(attacker, true)
 	defenderPower := m.GetPower(defender, false)
 
-	m.HandleFx(NewContext(m, &Battle{Attacker: attacker, AttackerPower: attackerPower, Defender: defender, DefenderPower: defenderPower, Blocked: blocked}))
+	m.HandleFx(NewContext(m, &Battle{Attacker: attacker, AttackerPower: attackerPower, Defender: defender, DefenderPower: defenderPower, Blocked: blocked, FromAttackPlayer: fromAttackPlayer}))
 
 	m.BroadcastState()
 


### PR DESCRIPTION
## 📝 Summary

Small Refactor for Carbonite Scarab to correctly use WheneverThisAttackPlayerAndBecomesBlocked.

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Carbonite Scarab was bugged before because Battle event wasn't giving enough information if the event was triggered from AttackPlayer sequence or from AttackCreature sequence.
- It could also be cancelled and the turbo rush effect of Carbonite was still wrongly in place.

## 🔧 Other Changes

- Carbonite Scarab refactor

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it