### PR TITLE
Fix for Gigaberos Quality of Life effect.

### DIFF
--- a/game/cards/dm02/rock_beast.go
+++ b/game/cards/dm02/rock_beast.go
@@ -48,8 +48,6 @@ func Bombersaur(c *match.Card) {
 	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Fire}
 
-	c.Use(fx.Creature, fx.When(fx.Destroyed, func(card *match.Card, ctx *match.Context) {
-		fx.EachPlayerDestroysMana(card, ctx, 2)
-	}))
+	c.Use(fx.Creature, fx.When(fx.Destroyed, fx.EachPlayerDestroys2Mana))
 
 }

--- a/game/fx/destroy_effects.go
+++ b/game/fx/destroy_effects.go
@@ -6,10 +6,14 @@ import (
 )
 
 func EachPlayerDestroys1Mana(card *match.Card, ctx *match.Context) {
-	EachPlayerDestroysMana(card, ctx, 1)
+	eachPlayerDestroysMana(card, ctx, 1)
 }
 
-func EachPlayerDestroysMana(card *match.Card, ctx *match.Context, quantity int) {
+func EachPlayerDestroys2Mana(card *match.Card, ctx *match.Context) {
+	eachPlayerDestroysMana(card, ctx, 2)
+}
+
+func eachPlayerDestroysMana(card *match.Card, ctx *match.Context, quantity int) {
 
 	players := make([]*match.Player, 0)
 	players = append(players, card.Player)
@@ -31,9 +35,9 @@ func EachPlayerDestroysMana(card *match.Card, ctx *match.Context, quantity int) 
 			quantity,
 			quantity,
 			false,
-		).Map(func(manaCard *match.Card) {
-			p.MoveCard(manaCard.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
-			ctx.Match.ReportActionInChat(p, fmt.Sprintf("%s effect: %s moved from MZ to GY", card.Name, manaCard.Name))
+		).Map(func(x *match.Card) {
+			p.MoveCard(x.ID, match.MANAZONE, match.GRAVEYARD, card.ID)
+			ctx.Match.ReportActionInChat(p, fmt.Sprintf("%s effect: %s moved from mana zone to graveyard", card.Name, x.Name))
 		})
 
 	}


### PR DESCRIPTION
## 📝 Summary

Now it detects if you don't have at least 2 other creatures in the BZ and automatically kills Gigaberos.

Only if you have at least 2 other creatures in the BZ, it gives you the chance to pick what to do.

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Before, Gigaberos wrongly was using a MultiSelect implementation for his effect.
- Now it detects in what case the player is and correctly handles both the situations.

## 🔧 Other Changes

- Small naming change to fx.eachPlayerDestroysMana.

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it