### PR TITLE
Fixed Nariel interaction with Machai

### DIFF
--- a/game/cards/dm08/light_bringer.go
+++ b/game/cards/dm08/light_bringer.go
@@ -19,46 +19,93 @@ func NarielTheOracle(c *match.Card) {
 	c.ManaCost = 4
 	c.ManaRequirement = []string{civ.Light}
 
-	c.Use(fx.Creature, func(card *match.Card, ctx *match.Context) {
-		if card.Zone != match.BATTLEZONE {
-			return
-		}
+	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
+		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
+			fx.Find(
+				card.Player,
+				match.BATTLEZONE,
+			).Map(func(x *match.Card) {
+				x.RemoveConditionBySource(card.ID)
+			})
 
-		if event, ok := ctx.Event.(*match.AttackPlayer); ok {
-			creature, err := ctx.Match.CurrentPlayer().Player.GetCard(event.CardID, match.BATTLEZONE)
-			if err != nil {
+			fx.Find(
+				ctx2.Match.Opponent(card.Player),
+				match.BATTLEZONE,
+			).Map(func(x *match.Card) {
+				x.RemoveConditionBySource(card.ID)
+			})
+
+			if card.Zone != match.BATTLEZONE {
+				exit()
 				return
 			}
 
-			if !creature.HasCondition(cnd.IgnoreCantAttack) && ctx.Match.GetPower(creature, false) >= 3000 {
-				ctx.Match.WarnPlayer(creature.Player, fmt.Sprintf("%s can't attack due to %s's effect.", creature.Name, card.Name))
-				ctx.InterruptFlow()
-			}
-		}
-
-		if event, ok := ctx.Event.(*match.AttackCreature); ok {
-			creature, err := ctx.Match.CurrentPlayer().Player.GetCard(event.CardID, match.BATTLEZONE)
-			if err != nil {
+			if _, ok := ctx2.Event.(*match.GetPowerEvent); ok {
 				return
 			}
 
-			if ctx.Match.GetPower(creature, false) >= 3000 {
-				ctx.Match.WarnPlayer(creature.Player, fmt.Sprintf("%s can't attack due to %s's effect.", creature.Name, card.Name))
-				ctx.InterruptFlow()
-			}
-		}
+			if event, ok := ctx2.Event.(*match.AttackPlayer); ok {
+				creature, err := ctx2.Match.CurrentPlayer().Player.GetCard(event.CardID, match.BATTLEZONE)
+				if err != nil {
+					return
+				}
 
-		if event, ok := ctx.Event.(*match.TapAbility); ok {
-			creature, err := ctx.Match.CurrentPlayer().Player.GetCard(event.CardID, match.BATTLEZONE)
-			if err != nil {
-				return
+				if !creature.HasCondition(cnd.IgnoreCantAttack) && ctx2.Match.GetPower(creature, false) >= 3000 {
+					ctx2.Match.WarnPlayer(creature.Player, fmt.Sprintf("%s can't attack due to %s's effect.", creature.Name, card.Name))
+					ctx2.InterruptFlow()
+				}
 			}
 
-			if !creature.HasCondition(cnd.IgnoreCantAttack) && ctx.Match.GetPower(creature, false) >= 3000 {
-				ctx.Match.WarnPlayer(creature.Player, fmt.Sprintf("%s can't use tap ability due to %s's effect.", creature.Name, card.Name))
-				ctx.InterruptFlow()
+			if event, ok := ctx2.Event.(*match.AttackCreature); ok {
+				creature, err := ctx2.Match.CurrentPlayer().Player.GetCard(event.CardID, match.BATTLEZONE)
+				if err != nil {
+					return
+				}
+
+				if ctx2.Match.GetPower(creature, false) >= 3000 {
+					ctx2.Match.WarnPlayer(creature.Player, fmt.Sprintf("%s can't attack due to %s's effect.", creature.Name, card.Name))
+					ctx2.InterruptFlow()
+				}
 			}
-		}
-	})
+
+			if event, ok := ctx2.Event.(*match.TapAbility); ok {
+				creature, err := ctx2.Match.CurrentPlayer().Player.GetCard(event.CardID, match.BATTLEZONE)
+				if err != nil {
+					return
+				}
+
+				if !creature.HasCondition(cnd.IgnoreCantAttack) && ctx2.Match.GetPower(creature, false) >= 3000 {
+					ctx2.Match.WarnPlayer(creature.Player, fmt.Sprintf("%s can't use tap ability due to %s's effect.", creature.Name, card.Name))
+					ctx2.InterruptFlow()
+				}
+			}
+
+			fx.FindFilter(
+				card.Player,
+				match.BATTLEZONE,
+				func(x *match.Card) bool {
+					return ctx2.Match.GetPower(x, false) >= 3000
+				},
+			).Map(func(x *match.Card) {
+				x.AddUniqueSourceCondition(cnd.CantAttackCreatures, nil, card.ID)
+				if !x.HasCondition(cnd.IgnoreCantAttack) {
+					x.AddUniqueSourceCondition(cnd.CantAttackPlayers, nil, card.ID)
+				}
+			})
+
+			fx.FindFilter(
+				ctx2.Match.Opponent(card.Player),
+				match.BATTLEZONE,
+				func(x *match.Card) bool {
+					return ctx2.Match.GetPower(x, false) >= 3000
+				},
+			).Map(func(x *match.Card) {
+				x.AddUniqueSourceCondition(cnd.CantAttackCreatures, nil, card.ID)
+				if !x.HasCondition(cnd.IgnoreCantAttack) {
+					x.AddUniqueSourceCondition(cnd.CantAttackPlayers, nil, card.ID)
+				}
+			})
+		})
+	}))
 
 }

--- a/game/cards/dm08/light_bringer.go
+++ b/game/cards/dm08/light_bringer.go
@@ -21,6 +21,10 @@ func NarielTheOracle(c *match.Card) {
 
 	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
+			if _, ok := ctx2.Event.(*match.GetPowerEvent); ok {
+				return
+			}
+
 			fx.Find(
 				card.Player,
 				match.BATTLEZONE,
@@ -37,10 +41,6 @@ func NarielTheOracle(c *match.Card) {
 
 			if card.Zone != match.BATTLEZONE {
 				exit()
-				return
-			}
-
-			if _, ok := ctx2.Event.(*match.GetPowerEvent); ok {
 				return
 			}
 


### PR DESCRIPTION
## 📝 Summary

Fixed an issue where Nariel, the Oracle incorrectly interacted with creatures that are forced to attack each turn if able and have power >= 3000 (ex. Automated Weaponmaster Machai)

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Nariel would not stop Machai from attacking, thus the current player's turn would become un-endable.
- Now it works correctly, because Nariel uses a PersistentEffect that would also add CantAttack conditions on the affected cards, thus cards like Machai would correctly interact with Nariel now.

## 🔧 Other Changes

- 

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it