### PR TITLE
Grinning Hunger loophole bugfix 

### DIFF
--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -403,7 +403,9 @@ func selectMultipartBase(p *match.Player, m *match.Match, cards map[string][]*ma
 			}
 		}
 
-		newCardsMap[key] = newCards
+		if len(newCards) > 0 {
+			newCardsMap[key] = newCards
+		}
 	}
 
 	notEmpty := false
@@ -427,6 +429,14 @@ func selectMultipartBase(p *match.Player, m *match.Match, cards map[string][]*ma
 		max = totalCardsLength
 	} else if totalCardsLength < max {
 		max = totalCardsLength
+	}
+
+	// Bypass the selection pop-up if action is NOT cancellable and the selection is unambiguous, i.e. filtered cards length == min == max
+	// i.e. user doesn't have a choice
+	if !cancellable && min == max && totalCardsLength == min && len(cards) == 1 {
+		for key := range cards {
+			return cards[key]
+		}
 	}
 
 	if backsideOnly {


### PR DESCRIPTION
## 📝 Summary

Grinning Hunger bugfix -- now correctly defaults to one zone (battlezone or shields) if the other zone doesn't have cards. Before you could exploit a loophole by choosing the empty zone (basically skipping the spell effect).

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Grinning Hunger loophole. Before bugfix, opponent was able to exploit a loophole if one of the zones would not have any card.

## 🔧 Other Changes

- Improved selectMultipartBase with a check for unambigous selection, similar to the check used in fx.Select.

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it