### PR TITLE
Essence Elf, Elf-X and Cocco Lupia refactor

### DIFF
--- a/game/fx/quality_of_life.go
+++ b/game/fx/quality_of_life.go
@@ -75,9 +75,38 @@ func FindFilter(p *match.Player, collection string, h func(card *match.Card) boo
 
 }
 
+// FindMultipleFilter returns a CardCollection matching the filter
+// from multiple containers specified in collections slice
+func FindMultipleFilter(p *match.Player, collections []string, h func(card *match.Card) bool) CardCollection {
+
+	result := CardCollection{}
+
+	for _, collection := range collections {
+		container, err := p.Container(collection)
+
+		if err != nil {
+			return result
+		}
+
+		for _, card := range container {
+			if h(card) {
+				result = append(result, card)
+			}
+		}
+	}
+
+	return result
+
+}
+
 // Find returns a CardCollection for the specified container
 func Find(p *match.Player, collection string) CardCollection {
 	return FindFilter(p, collection, func(x *match.Card) bool { return true })
+}
+
+// FindMultiple returns a CardCollection for the specified containers
+func FindMultiple(p *match.Player, collections []string) CardCollection {
+	return FindMultipleFilter(p, collections, func(x *match.Card) bool { return true })
 }
 
 // When performs the specified function if the test is successful


### PR DESCRIPTION
## 📝 Summary

Essence Elf, Elf-X and Cocco Lupia refactor.

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Especially for Android mobile browsers (where drag & drop doesn't work), fixed a bug where the button "Add to battlezone" won't be available for some cards immediately after Essence Elf, Elf-X or Cocco Lupia would be summoned, due to the internal implementation of the reduction effect.
- Now implementation uses persistent effect, so the button gets rendered correctly even during the same turn for the player that summons Essence Elf, Elf-X or Cocco Lupia, unblocking Android mobile web players.

## 🔧 Other Changes

- Refactor all 3 implementations to be aligned

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it