### PR TITLE
DM-10 batch no. 13 of cards. Total of 6 nature cards.

### DIFF
--- a/game/cards/dm10/earth_dragon.go
+++ b/game/cards/dm10/earth_dragon.go
@@ -1,0 +1,28 @@
+package dm10
+
+import (
+	"duel-masters/game/civ"
+	"duel-masters/game/family"
+	"duel-masters/game/fx"
+	"duel-masters/game/match"
+)
+
+// TerradragonCusdalf ...
+func TerradragonCusdalf(c *match.Card) {
+
+	c.Name = "Terradragon Cusdalf"
+	c.Power = 1000
+	c.Civ = civ.Nature
+	c.Family = []string{family.WildVeggies}
+	c.ManaCost = 2
+	c.ManaRequirement = []string{civ.Nature}
+
+	c.Use(fx.Creature, fx.Doublebreaker, fx.PowerAttacker4000, func(card *match.Card, ctx *match.Context) {
+		if event, ok := ctx.Event.(*match.UntapManaEvent); ok && card.Zone == match.BATTLEZONE {
+			if event.CurrentPlayer == card.Player {
+				ctx.InterruptFlow()
+			}
+		}
+	})
+
+}

--- a/game/cards/dm10/earth_dragon.go
+++ b/game/cards/dm10/earth_dragon.go
@@ -11,10 +11,10 @@ import (
 func TerradragonCusdalf(c *match.Card) {
 
 	c.Name = "Terradragon Cusdalf"
-	c.Power = 1000
+	c.Power = 7000
 	c.Civ = civ.Nature
-	c.Family = []string{family.WildVeggies}
-	c.ManaCost = 2
+	c.Family = []string{family.EarthDragon}
+	c.ManaCost = 5
 	c.ManaRequirement = []string{civ.Nature}
 
 	c.Use(fx.Creature, fx.Doublebreaker, fx.PowerAttacker4000, func(card *match.Card, ctx *match.Context) {

--- a/game/cards/dm10/horned_beast.go
+++ b/game/cards/dm10/horned_beast.go
@@ -1,0 +1,36 @@
+package dm10
+
+import (
+	"duel-masters/game/civ"
+	"duel-masters/game/family"
+	"duel-masters/game/fx"
+	"duel-masters/game/match"
+)
+
+// TwitchHornTheAgressor ...
+func TwitchHornTheAgressor(c *match.Card) {
+
+	c.Name = "Twitch Horn, the Aggressor"
+	c.Power = 2000
+	c.Civ = civ.Nature
+	c.Family = []string{family.HornedBeast}
+	c.ManaCost = 6
+	c.ManaRequirement = []string{civ.Nature}
+
+	c.PowerModifier = func(m *match.Match, attacking bool) int {
+		if attacking {
+			return len(fx.FindFilter(
+				c.Player,
+				match.MANAZONE,
+				func(x *match.Card) bool {
+					return x.Tapped
+				},
+			)) * 2000
+		}
+
+		return 0
+	}
+
+	c.Use(fx.Creature)
+
+}

--- a/game/cards/dm10/spells.go
+++ b/game/cards/dm10/spells.go
@@ -13,7 +13,7 @@ func Soulswap(c *match.Card) {
 
 	c.Name = "Soulswap"
 	c.Civ = civ.Nature
-	c.ManaCost = 2
+	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Nature}
 
 	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
@@ -80,10 +80,10 @@ func Soulswap(c *match.Card) {
 
 }
 
-// ThirstOfTheHunt ...
-func ThirstOfTheHunt(c *match.Card) {
+// ThirstForTheHunt ...
+func ThirstForTheHunt(c *match.Card) {
 
-	c.Name = "Thirst of the Hunt"
+	c.Name = "Thirst for the Hunt"
 	c.Civ = civ.Nature
 	c.ManaCost = 1
 	c.ManaRequirement = []string{civ.Nature}

--- a/game/cards/dm10/spells.go
+++ b/game/cards/dm10/spells.go
@@ -1,0 +1,100 @@
+package dm10
+
+import (
+	"duel-masters/game/civ"
+	"duel-masters/game/cnd"
+	"duel-masters/game/fx"
+	"duel-masters/game/match"
+	"fmt"
+)
+
+// Soulswap ...
+func Soulswap(c *match.Card) {
+
+	c.Name = "Soulswap"
+	c.Civ = civ.Nature
+	c.ManaCost = 2
+	c.ManaRequirement = []string{civ.Nature}
+
+	c.Use(fx.Spell, fx.ShieldTrigger, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
+		cards := make(map[string][]*match.Card)
+
+		myCards, err := card.Player.Container(match.BATTLEZONE)
+
+		if err != nil {
+			return
+		}
+
+		opponentCards, err := ctx.Match.Opponent(card.Player).Container(match.BATTLEZONE)
+
+		if err != nil {
+			return
+		}
+
+		if len(myCards) < 1 && len(opponentCards) < 1 {
+			return
+		}
+
+		cards["Your creatures"] = myCards
+		cards["Opponent's creatures"] = opponentCards
+
+		fx.SelectMultipart(
+			card.Player,
+			ctx.Match,
+			cards,
+			fmt.Sprintf("%s's effect: You may choose a creature in the battle zone and put it into its owner's mana zone.\r\n If you do, choose a non-evolution creature in that player's mana zone that costs the same as or less than the number of cards in that mana zone.\r\n That player puts that creature into the battle zone.", card.Name),
+			1,
+			1,
+			true,
+		).Map(func(x *match.Card) {
+			_, err := x.Player.MoveCard(x.ID, match.BATTLEZONE, match.MANAZONE, card.ID)
+
+			if err == nil {
+				ctx.Match.ReportActionInChat(x.Player, fmt.Sprintf("%s was put into %s's mana zone from his battle zone.", x.Name, x.Player.Username()))
+			}
+
+			manaZone, _ := x.Player.Container(match.MANAZONE)
+
+			if manaZone != nil {
+				manaZoneLen := len(manaZone)
+
+				fx.SelectFilter(
+					card.Player,
+					ctx.Match,
+					x.Player,
+					match.MANAZONE,
+					fmt.Sprintf("Choose a non-evolution creature in %s's mana zone that costs the same as or less than the number of cards in that mana zone.\r\n %s puts that creature into the battle zone.", x.Player.Username(), x.Player.Username()),
+					1,
+					1,
+					false,
+					func(x *match.Card) bool {
+						return x.HasCondition(cnd.Creature) && !x.HasCondition(cnd.Evolution) && x.ManaCost <= manaZoneLen
+					},
+					false,
+				).Map(func(x *match.Card) {
+					fx.ForcePutCreatureIntoBZ(ctx, x, match.MANAZONE, card)
+				})
+			}
+		})
+	}))
+
+}
+
+// ThirstOfTheHunt ...
+func ThirstOfTheHunt(c *match.Card) {
+
+	c.Name = "Thirst of the Hunt"
+	c.Civ = civ.Nature
+	c.ManaCost = 1
+	c.ManaRequirement = []string{civ.Nature}
+
+	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
+		fx.Find(
+			card.Player,
+			match.BATTLEZONE,
+		).Map(func(x *match.Card) {
+			x.AddUniqueSourceCondition(cnd.PowerAttacker, 1000, card.ID)
+		})
+	}))
+
+}

--- a/game/cards/dm10/wild_veggies.go
+++ b/game/cards/dm10/wild_veggies.go
@@ -1,0 +1,43 @@
+package dm10
+
+import (
+	"duel-masters/game/civ"
+	"duel-masters/game/family"
+	"duel-masters/game/fx"
+	"duel-masters/game/match"
+	"fmt"
+)
+
+// ScowlingTomato ...
+func ScowlingTomato(c *match.Card) {
+
+	c.Name = "Scowling Tomato"
+	c.Power = 2000
+	c.Civ = civ.Nature
+	c.Family = []string{family.WildVeggies}
+	c.ManaCost = 2
+	c.ManaRequirement = []string{civ.Nature}
+
+	c.Use(fx.Creature)
+
+}
+
+// ShamanBrocolli ...
+func ShamanBrocolli(c *match.Card) {
+
+	c.Name = "Shaman Brocolli"
+	c.Power = 1000
+	c.Civ = civ.Nature
+	c.Family = []string{family.WildVeggies}
+	c.ManaCost = 2
+	c.ManaRequirement = []string{civ.Nature}
+
+	c.Use(fx.Creature, fx.When(fx.WouldBeDestroyed, func(card *match.Card, ctx *match.Context) {
+		_, err := card.Player.MoveCard(card.ID, match.BATTLEZONE, match.MANAZONE, card.ID)
+
+		if err == nil {
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was moved to mana zone instead of being destroyed.", card.Name))
+		}
+	}))
+
+}

--- a/game/cards/dm10/wild_veggies.go
+++ b/game/cards/dm10/wild_veggies.go
@@ -22,10 +22,10 @@ func ScowlingTomato(c *match.Card) {
 
 }
 
-// ShamanBrocolli ...
-func ShamanBrocolli(c *match.Card) {
+// ShamanBroccoli ...
+func ShamanBroccoli(c *match.Card) {
 
-	c.Name = "Shaman Brocolli"
+	c.Name = "Shaman Broccoli"
 	c.Power = 1000
 	c.Civ = civ.Nature
 	c.Family = []string{family.WildVeggies}

--- a/game/cards/repository.go
+++ b/game/cards/repository.go
@@ -711,10 +711,10 @@ var DM09 = map[string]match.CardConstructor{
 
 var DM10 = map[string]match.CardConstructor{
 	"2e10b4fb-3f85-4144-8762-51c04fe609d5": dm10.ScowlingTomato,
-	"b22f0d6b-7703-4bd4-b97f-4389f907577e": dm10.ShamanBrocolli,
+	"b22f0d6b-7703-4bd4-b97f-4389f907577e": dm10.ShamanBroccoli,
 	"a82ec211-588c-4308-95be-798581045e31": dm10.Soulswap,
 	"45b557c2-6beb-4c9d-aa2b-0f7804a3e214": dm10.TerradragonCusdalf,
-	"244080a8-c85f-4e05-b403-dfae3fac0618": dm10.ThirstOfTheHunt,
+	"244080a8-c85f-4e05-b403-dfae3fac0618": dm10.ThirstForTheHunt,
 	"47875b7c-6472-41d9-8994-7c21306a1a99": dm10.TwitchHornTheAgressor,
 }
 

--- a/game/cards/repository.go
+++ b/game/cards/repository.go
@@ -10,6 +10,7 @@ import (
 	"duel-masters/game/cards/dm07"
 	"duel-masters/game/cards/dm08"
 	"duel-masters/game/cards/dm09"
+	"duel-masters/game/cards/dm10"
 	"duel-masters/game/cards/promo"
 	"duel-masters/game/match"
 )
@@ -25,6 +26,7 @@ var Sets = map[string]*map[string]match.CardConstructor{
 	"dm-07": &DM07,
 	"dm-08": &DM08,
 	"dm-09": &DM09,
+	"dm-10": &DM10,
 	"promo": &Promo,
 }
 
@@ -694,6 +696,15 @@ var DM09 = map[string]match.CardConstructor{
 	"cf96ecd5-481a-4a63-b8f1-61731525d956": dm09.KelpCandle,
 	"83ac5a3a-1b3d-43f9-a08e-4415e5f478ff": dm09.AzaghastTyrantOfShadows,
 	"da93d9d0-b569-408d-af93-b4a4286fc91f": dm09.BatDoctorShadowOfUndeath,
+}
+
+var DM10 = map[string]match.CardConstructor{
+	"2e10b4fb-3f85-4144-8762-51c04fe609d5": dm10.ScowlingTomato,
+	"b22f0d6b-7703-4bd4-b97f-4389f907577e": dm10.ShamanBrocolli,
+	"a82ec211-588c-4308-95be-798581045e31": dm10.Soulswap,
+	"45b557c2-6beb-4c9d-aa2b-0f7804a3e214": dm10.TerradragonCusdalf,
+	"244080a8-c85f-4e05-b403-dfae3fac0618": dm10.ThirstOfTheHunt,
+	"47875b7c-6472-41d9-8994-7c21306a1a99": dm10.TwitchHornTheAgressor,
 }
 
 // Promo is a map with all the card id's in the game and corresponding CardConstructor for promotional exclusive cards

--- a/game/family/families.go
+++ b/game/family/families.go
@@ -54,6 +54,7 @@ const (
 	EarthDragon     = "Earth Dragon"
 	ZombieDragon    = "Zombie Dragon"
 	MechaDelSol     = "Mecha del Sol"
+	WildVeggies     = "Wild Veggies"
 )
 
 var Cybers = []string{CyberCluster, CyberLord, CyberVirus}

--- a/game/fx/creature.go
+++ b/game/fx/creature.go
@@ -21,7 +21,7 @@ func Creature(card *match.Card, ctx *match.Context) {
 
 		card.AddCondition(cnd.Creature, nil, nil)
 
-		if ctx.Match.IsPlayerTurn(card.Player) {
+		if ctx.Match.IsPlayerTurn(card.Player) && card.Zone == match.BATTLEZONE {
 			card.Tapped = false
 		}
 

--- a/game/fx/creature.go
+++ b/game/fx/creature.go
@@ -21,7 +21,7 @@ func Creature(card *match.Card, ctx *match.Context) {
 
 		card.AddCondition(cnd.Creature, nil, nil)
 
-		if ctx.Match.IsPlayerTurn(card.Player) && card.Zone == match.BATTLEZONE {
+		if ctx.Match.IsPlayerTurn(card.Player) && card.Zone != match.MANAZONE {
 			card.Tapped = false
 		}
 

--- a/game/match/events.go
+++ b/game/match/events.go
@@ -14,6 +14,11 @@ type CardPlayedEvent struct {
 	CardID string
 }
 
+// UntapManaEvent is fired when the player attempts to untap mana before untap step event
+type UntapManaEvent struct {
+	CurrentPlayer *Player
+}
+
 // ChargeManaEvent is fired when the player attempts to charge mana
 type ChargeManaEvent struct {
 	CardID string

--- a/game/match/match.go
+++ b/game/match/match.go
@@ -978,6 +978,20 @@ func (m *Match) BeginNewTurn(repeatTurn ...bool) {
 	m.CurrentPlayer().Player.HasChargedMana = false
 	m.CurrentPlayer().Player.CanChargeMana = true
 
+	ctx = NewContext(m, &UntapManaEvent{
+		CurrentPlayer: m.CurrentPlayer().Player,
+	})
+
+	m.HandleFx(ctx)
+
+	if !ctx.Cancelled() {
+		if mana, err := m.CurrentPlayer().Player.Container(MANAZONE); err == nil {
+			for _, c := range mana {
+				c.Tapped = false
+			}
+		}
+	}
+
 	m.BroadcastState()
 
 	m.UntapStep()
@@ -988,12 +1002,6 @@ func (m *Match) BeginNewTurn(repeatTurn ...bool) {
 func (m *Match) UntapStep() {
 
 	m.Step = &UntapStep{}
-
-	if mana, err := m.CurrentPlayer().Player.Container(MANAZONE); err == nil {
-		for _, c := range mana {
-			c.Tapped = false
-		}
-	}
 
 	ctx := NewContext(m, m.Step)
 


### PR DESCRIPTION
## 📝 Summary

DM-10 batch no. 13 of cards. Total of 6 nature cards.

## 🎴 New Cards Added

- Scowling Tomato
- Shaman Broccoli
- Soulswap
- Terradragon Cusdalf
- Thirst For The Hunt
- Twitch Horn, The Agressor

## 🐞 Bugs Fixed

- 

## 🔧 Other Changes

- Added a new event, "UntapManaEvent", in order to correctly handle Terradragon Cusdalf effect.
- Also added a check in Untap step for creatures, to untap the creature only if it's in the battlezone, so that Cusdalf's effect could be correctly implemented via UntapManaEvent,

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it