### PR TITLE
fix(elf-x): apply mana reduction in the same turn as summon

### DIFF
--- a/sim/game/cards/dm02/tree_folk.go
+++ b/sim/game/cards/dm02/tree_folk.go
@@ -19,6 +19,23 @@ func ElfX(c *match.Card) {
 	c.ManaRequirement = []string{civ.Nature}
 
 	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
+		applyDiscount := func() {
+			fx.FindFilter(
+				card.Player,
+				match.HAND,
+				func(x *match.Card) bool {
+					return x.HasCondition(cnd.Creature)
+				},
+			).Map(func(x *match.Card) {
+				x.AddUniqueSourceCondition(cnd.ReducedCost, 1, card.ID)
+			})
+		}
+
+		// Apply immediately so BroadcastState after this summon reflects the discount
+		if ctx.Match.IsPlayerTurn(card.Player) {
+			applyDiscount()
+		}
+
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 			if card.Zone != match.BATTLEZONE {
 				// we use fx.FindMultipleFilter for edge cases when elf x might leave the BZ
@@ -42,15 +59,7 @@ func ElfX(c *match.Card) {
 				return
 			}
 
-			fx.FindFilter(
-				card.Player,
-				match.HAND,
-				func(x *match.Card) bool {
-					return x.HasCondition(cnd.Creature)
-				},
-			).Map(func(x *match.Card) {
-				x.AddUniqueSourceCondition(cnd.ReducedCost, 1, card.ID)
-			})
+			applyDiscount()
 		})
 	}))
 

--- a/sim/game/match/match.go
+++ b/sim/game/match/match.go
@@ -2134,12 +2134,14 @@ func spawnCardsToGivenZones(m *Match,
 		for _, z := range zones {
 			for i := range cardsToSpawn {
 				for range count {
-					card := player.SpawnCard(cardsToSpawn[i], z)
-					if card != nil {
-						// Run this card's own handlers with UntapStep so conditions like cnd.Creature and cnd.Spell are initialised, matching real game behaviour
-						for _, h := range card.handlers {
-							h(card, ctx)
-						}
+					card, err := player.SpawnCard(cardsToSpawn[i], z)
+					if err != nil {
+						logrus.Warnf("Failed to spawn card %s: %v", cardsToSpawn[i], err)
+						continue
+					}
+					// Run this card's own handlers with UntapStep so conditions like cnd.Creature and cnd.Spell are initialised, matching real game behaviour
+					for _, h := range card.handlers {
+						h(card, ctx)
 					}
 				}
 			}

--- a/sim/game/match/match.go
+++ b/sim/game/match/match.go
@@ -2129,10 +2129,18 @@ func spawnCardsToGivenZones(m *Match,
 			}
 		}
 
+		ctx := NewContext(m, &UntapStep{})
+
 		for _, z := range zones {
 			for i := range cardsToSpawn {
 				for range count {
-					player.SpawnCard(cardsToSpawn[i], z)
+					card := player.SpawnCard(cardsToSpawn[i], z)
+					if card != nil {
+						// Run this card's own handlers with UntapStep so conditions like cnd.Creature and cnd.Spell are initialised, matching real game behaviour
+						for _, h := range card.handlers {
+							h(card, ctx)
+						}
+					}
 				}
 			}
 		}

--- a/sim/game/match/player.go
+++ b/sim/game/match/player.go
@@ -282,7 +282,7 @@ func (p *Player) DestroyDeck() {
 
 // SpawnCard creates a new card from an id and adds it to the players' given zone
 // used for debugging and development
-func (p *Player) SpawnCard(id string, zone string) *Card {
+func (p *Player) SpawnCard(id string, zone string) (*Card, error) {
 
 	p.mutex.Lock()
 
@@ -291,8 +291,7 @@ func (p *Player) SpawnCard(id string, zone string) *Card {
 	c, err := NewCard(p, id)
 
 	if err != nil {
-		logrus.Warnf("Failed to create card with id %s", id)
-		return nil
+		return nil, err
 	}
 
 	c.Zone = zone
@@ -311,11 +310,10 @@ func (p *Player) SpawnCard(id string, zone string) *Card {
 	case GRAVEYARD:
 		p.graveyard = append(p.graveyard, c)
 	default:
-		logrus.Warnf("Failed to create card with id %s - invalid zone", id)
-		return nil
+		return nil, fmt.Errorf("invalid zone %s for card %s", zone, id)
 	}
 
-	return c
+	return c, nil
 }
 
 // ShuffleDeck randomizes the order of cards in the players deck

--- a/sim/game/match/player.go
+++ b/sim/game/match/player.go
@@ -282,7 +282,7 @@ func (p *Player) DestroyDeck() {
 
 // SpawnCard creates a new card from an id and adds it to the players' given zone
 // used for debugging and development
-func (p *Player) SpawnCard(id string, zone string) {
+func (p *Player) SpawnCard(id string, zone string) *Card {
 
 	p.mutex.Lock()
 
@@ -292,7 +292,7 @@ func (p *Player) SpawnCard(id string, zone string) {
 
 	if err != nil {
 		logrus.Warnf("Failed to create card with id %s", id)
-		return
+		return nil
 	}
 
 	c.Zone = zone
@@ -312,8 +312,10 @@ func (p *Player) SpawnCard(id string, zone string) {
 		p.graveyard = append(p.graveyard, c)
 	default:
 		logrus.Warnf("Failed to create card with id %s - invalid zone", id)
-		return
+		return nil
 	}
+
+	return c
 }
 
 // ShuffleDeck randomizes the order of cards in the players deck


### PR DESCRIPTION
## 📝 Summary

Elf-X's mana reduction was not applying in the same turn it was summoned. The persistent effect was registered but not yet invoked when `BroadcastState` ran, so creatures in hand required their full cost. This is fixed by applying the discount immediately on `InTheBattlezone` before `BroadcastState` runs.

Additionally, in the dev environment, cards added mid-turn via `/add` or `/init` also did not receive the same-turn discount because they missed that turn's `UntapStep`, leaving `cnd.Creature` unset. This is fixed by running spawned cards through a synthetic `UntapStep` on creation.

Closes #379

## 🐞 Bugs Fixed

- Elf-X mana reduction now applies in the same turn it is summoned
- Cards added via `/add` or `/init` mid-turn now also receive the same-turn discount

## 🔧 Other Changes

- `sim/game/cards/dm02/tree_folk.go`: Added an immediate `applyDiscount()` call inside the `InTheBattlezone` handler, before `ApplyPersistentEffect`. The discount logic is extracted into a local `applyDiscount` closure, used in both the `InTheBattlezone` handler and the persistent effect.
- `sim/game/match/match.go`: After each `SpawnCard`, the new card's handlers are run with a synthetic `UntapStep` context. This is because cards spawned mid-turn via `/add` or `/init` miss that turn's `UntapStep`, so they lack `cnd.Creature` for the remainder of the turn. This caused same-turn discount to fail for those cards (next-turn worked fine since `UntapStep` would catch them).
- `sim/game/match/player.go`: `SpawnCard` now returns `*Card` instead of nothing. This is to give `spawnCardsToGivenZones` in `sim/game/match/match.go` access to the newly created card for initialization.

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

No changes to the frontend