### PR TITLE
Fix Zero Nemesis triggering from non-battlezone (#391)

### DIFF
--- a/sim/game/fx/quality_of_life.go
+++ b/sim/game/fx/quality_of_life.go
@@ -713,6 +713,10 @@ func AttackConfirmed(card *match.Card, ctx *match.Context) bool {
 // OneOfMyCreaturesAttacksConfirmed returns true
 // if one of the player's creatures is attacking and it cannot be cancelled
 func OneOfMyCreaturesAttacksConfirmed(card *match.Card, ctx *match.Context) bool {
+	if card.Zone != match.BATTLEZONE {
+		return false
+	}
+	
 	if event, ok := ctx.Event.(*match.AttackConfirmed); ok {
 		_, err := card.Player.GetCard(event.CardID, match.BATTLEZONE)
 


### PR DESCRIPTION
## 📝 Summary

Fixes #391. Zero Nemesis, Shadow of Panic's "Whenever one of your creatures attacks, your opponent discards a card at random" effect was triggering even when the card was in hand, mana zone, or any zone outside the battle zone.

The root cause is in `fx.OneOfMyCreaturesAttacksConfirmed`, which only verified the attacking creature was in the battle zone but never checked that the card hosting the ability was. Similar predicates in the codebase already do this check (e.g. `OppShieldTriggerCast`), so the fix brings this one in line.

The fix is a one-liner at the top of the predicate:

```go
if card.Zone != match.BATTLEZONE {
    return false
}
```

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Fixed an issue where Zero Nemesis, Shadow of Panic's effect would trigger even when the card was in the hand, mana zone, or other non-battlezone areas (closes #391)

## 🔧 Other Changes

- 

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

Manually tested in a local match:

- [x] Zero Nemesis in hand -> one of my creatures attacks -> opponent does NOT discard
- [x] Zero Nemesis in mana zone -> one of my creatures attacks -> opponent does NOT discard
- [x] Zero Nemesis evolved into the battle zone -> one of my creatures attacks -> opponent discards as expected
- [x] Two Zero Nemesis in the battle zone -> one of my creatures attacks -> opponent discards twice