### PR TITLE
Fix Siren Concerto allowing itself to be selected (#392)

### DIFF
--- a/sim/game/cards/dm10/spells.go
+++ b/sim/game/cards/dm10/spells.go
@@ -122,7 +122,7 @@ func SirenConcerto(c *match.Card) {
 			}
 		})
 
-		fx.Select(
+		fx.SelectFilter(
 			card.Player,
 			ctx.Match,
 			card.Player,
@@ -130,6 +130,8 @@ func SirenConcerto(c *match.Card) {
 			fmt.Sprintf("%s's effect: Put a card from your hand into your mana zone.", card.Name),
 			1,
 			1,
+			false,
+			func(x *match.Card) bool { return x.ID != card.ID },
 			false,
 		).Map(func(x *match.Card) {
 			_, err := card.Player.MoveCard(x.ID, match.HAND, match.MANAZONE, card.ID)


### PR DESCRIPTION
## 📝 Summary

Fixes #392. Siren Concerto's effect reads:

> Put a card from your mana zone into your hand. Then put a card from your hand into your mana zone.

The second prompt allowed the player to select the Siren Concerto itself, even though by Duel Masters rules a spell being cast is on the stack and not actually in the hand. Selecting it caused Siren Concerto to be put into the mana zone instead of the graveyard, effectively refunding its cost and turning the spell into a free mana-zone card swap.

The fix changes the second `fx.Select` to `fx.SelectFilter` with a predicate that excludes the casting card by ID:

```go
func(x *match.Card) bool { return x.ID != card.ID }
```

Cards retrieved from the mana zone in the first part of the effect remain selectable in the second part (this is correct per the rules — "then" implies sequential resolution, and the cost is still paid).

Note: while working on this I noticed Siren Concerto is also missing `fx.ShieldTrigger` in its `c.Use(...)` call despite the card text starting with "Shield trigger." Filed separately as #XXX to keep this PR focused.

## 🎴 New Cards Added

- 

## 🐞 Bugs Fixed

- Fixed an issue where Siren Concerto could select itself when choosing a card from hand to put into the mana zone, refunding its own cost (closes #392)

## 🔧 Other Changes

- 

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] The PR does not contain an excessive amount of changes that could have been split up into multiple PRs

## 📸 Screenshots (if applicable)

Manually tested in a local match:

- [x] Cast Siren Concerto with cards in hand and mana -> first prompt offers mana-zone cards -> pick one -> it moves to hand -> second prompt does NOT include Siren Concerto in the selectable list -> pick any other card -> it moves to mana -> Siren Concerto goes to graveyard
- [x] Cast Siren Concerto, retrieve Elf X from mana -> second prompt -> Elf X is still selectable (correct per the rules) -> pick Elf X -> Elf X goes back to mana -> Siren Concerto goes to graveyard
- [x] Cast Siren Concerto with only Siren Concerto in hand -> used Aqua Vehicle as the mana cost -> first prompt retrieves Aqua Vehicle to hand -> since Aqua Vehicle is the only eligible card for the second part of the effect, it is automatically placed back in the mana zone -> Siren Concerto goes to graveyard