### PR TITLE
Fix Balesk Baj the Timeburner incorrect interaction when bounced / killed after attacking without being blocked

### DIFF
--- a/sim/game/cards/dm09/armored_wyvern.go
+++ b/sim/game/cards/dm09/armored_wyvern.go
@@ -35,8 +35,11 @@ func BaleskBajTheTimeburner(c *match.Card) {
 			attacked = true
 		}),
 		fx.When(fx.EndOfMyTurn, func(card *match.Card, ctx *match.Context) {
+			// The "return to hand" and "take an extra turn" clauses are
+			// independent triggered abilities. Whether this one can resolve
+			// must not affect the other, which checks attacked on the later
+			// EndOfTurnStep.
 			if card.Zone != match.BATTLEZONE {
-				attacked = false
 				return
 			}
 
@@ -45,8 +48,6 @@ func BaleskBajTheTimeburner(c *match.Card) {
 
 				if err == nil {
 					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was returned to the %s's hand", card.Name, card.Player.Username()))
-				} else {
-					attacked = false
 				}
 			})
 		}),

--- a/sim/tests/cards/balesk_baj_the_timeburner_test.go
+++ b/sim/tests/cards/balesk_baj_the_timeburner_test.go
@@ -1,0 +1,93 @@
+package cards
+
+import (
+	"duel-masters/game/civ"
+	"duel-masters/game/cnd"
+	"duel-masters/game/family"
+	"duel-masters/game/match"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	baleskBajUID        = "4dbc114f-b53e-45f5-baa5-5ca33a5a3337"
+	baleskBajBlockerUID = "c7fec5e8-4e56-451b-a7b6-ad08680703a4" // La Byle, Seeker of the Winds (Blocker)
+	baleskBajSetupSrc   = "balesk_baj_test_setup"
+)
+
+func TestBaleskBajTheTimeburner(t *testing.T) {
+	t.Run("printed characteristics", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+		card := putCardInBattlezone(t, scn, player.Player, baleskBajUID, baleskBajSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		assertPrinted(t, card, "Balesk Baj, the Timeburner", 8000, 9, []string{civ.Fire})
+		assert.True(t, card.HasFamily(family.ArmoredWyvern))
+		assert.True(t, card.HasCondition(cnd.Evolution))
+		assert.True(t, card.HasCondition(cnd.DoubleBreaker))
+	})
+
+	t.Run("an unblocked attack returns it to hand and grants an extra turn", func(t *testing.T) {
+		scn, player, _ := setupDuel(t)
+		attacker := putCardInBattlezone(t, scn, player.Player, baleskBajUID, baleskBajSetupSrc)
+
+		action, err := scn.ActionAttackPlayer(player, attacker.ID)
+		require.NoError(t, err)
+		require.NoError(t, scn.ResolveAttack(player, action.Cards[0].CardID))
+
+		require.NoError(t, scn.ActionEndTurn(player))
+		assert.Equal(t, match.HAND, attacker.Zone)
+		assert.True(t, scn.Match.IsPlayerTurn(player.Player), "the extra turn keeps the same player on turn")
+	})
+
+	t.Run("a blocked attack does not grant an extra turn", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+		attacker := putCardInBattlezone(t, scn, player.Player, baleskBajUID, baleskBajSetupSrc)
+		blocker := putCardInBattlezone(t, scn, opponent.Player, baleskBajBlockerUID, baleskBajSetupSrc)
+		// Grant the Blocker keyword directly: a real untap step for the
+		// opponent would require ending player's turn first, which would
+		// bounce Balesk Baj back to hand before it ever got to attack.
+		blocker.AddUniqueSourceCondition(cnd.Blocker, true, blocker.ID)
+
+		action, err := scn.ActionAttackPlayer(player, attacker.ID)
+		require.NoError(t, err)
+		require.NoError(t, scn.ResolveAttack(player, action.Cards[0].CardID))
+		require.NoError(t, scn.SubmitAction(opponent, blocker.ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		require.NoError(t, scn.ActionEndTurn(player))
+		assert.Equal(t, match.HAND, attacker.Zone, "the return-to-hand clause is unconditional")
+		assert.False(t, scn.Match.IsPlayerTurn(player.Player), "a blocked attack must not grant an extra turn")
+	})
+
+	t.Run("being destroyed after an unblocked attack does not cancel the extra turn", func(t *testing.T) {
+		scn, player, _ := setupDuel(t)
+		attacker := putCardInBattlezone(t, scn, player.Player, baleskBajUID, baleskBajSetupSrc)
+
+		action, err := scn.ActionAttackPlayer(player, attacker.ID)
+		require.NoError(t, err)
+		require.NoError(t, scn.ResolveAttack(player, action.Cards[0].CardID))
+		require.Equal(t, match.BATTLEZONE, attacker.Zone)
+
+		// Simulate being destroyed by a shield trigger or other effect after
+		// the unblocked attack, but before the turn ends.
+		moved, err := player.Player.MoveCard(attacker.ID, match.BATTLEZONE, match.GRAVEYARD, baleskBajSetupSrc)
+		require.NoError(t, err)
+		require.Equal(t, match.GRAVEYARD, moved.Zone)
+		require.NoError(t, scn.WaitForEventLoop())
+
+		require.NoError(t, scn.ActionEndTurn(player))
+		assert.True(t, scn.Match.IsPlayerTurn(player.Player), "the extra turn already triggered at the unblocked attack")
+	})
+
+	t.Run("not attacking grants no extra turn", func(t *testing.T) {
+		scn, player, _ := setupDuel(t)
+		attacker := putCardInBattlezone(t, scn, player.Player, baleskBajUID, baleskBajSetupSrc)
+
+		require.NoError(t, scn.ActionEndTurn(player))
+		assert.Equal(t, match.HAND, attacker.Zone)
+		assert.False(t, scn.Match.IsPlayerTurn(player.Player))
+	})
+}

--- a/sim/tests/cards/balesk_baj_the_timeburner_test.go
+++ b/sim/tests/cards/balesk_baj_the_timeburner_test.go
@@ -90,4 +90,22 @@ func TestBaleskBajTheTimeburner(t *testing.T) {
 		assert.Equal(t, match.HAND, attacker.Zone)
 		assert.False(t, scn.Match.IsPlayerTurn(player.Player))
 	})
+
+	t.Run("the granted extra turn does not itself grant another one", func(t *testing.T) {
+		scn, player, _ := setupDuel(t)
+		attacker := putCardInBattlezone(t, scn, player.Player, baleskBajUID, baleskBajSetupSrc)
+
+		action, err := scn.ActionAttackPlayer(player, attacker.ID)
+		require.NoError(t, err)
+		require.NoError(t, scn.ResolveAttack(player, action.Cards[0].CardID))
+
+		require.NoError(t, scn.ActionEndTurn(player))
+		require.True(t, scn.Match.IsPlayerTurn(player.Player), "the extra turn was granted")
+
+		// On the granted extra turn itself, Balesk Baj already left the
+		// battle zone and does not attack again, so ending it must hand the
+		// turn over normally rather than granting a second extra turn.
+		require.NoError(t, scn.ActionEndTurn(player))
+		assert.False(t, scn.Match.IsPlayerTurn(player.Player), "the flag must not leak into the extra turn itself")
+	})
 }


### PR DESCRIPTION
## 📝 Summary

Fix Balesk Baj the Timeburner incorrect interaction when bounced / killed after attacking without being blocked

## 🎴 New Cards Added

-

## 🐞 Bugs Fixed

- Fix Balesk Baj's extra turn being cancelled by its own return-to-hand clause.
- "Return to hand" and "take an extra turn" are independent triggered
abilities sharing an `attacked` flag, checked on two different events
in sequence (EndStep, then EndOfTurnStep). The return-to-hand handler
reset `attacked = false` whenever the card wasn't in the battle zone,
as a side effect of skipping a now-impossible move. If the creature
was destroyed after an unblocked attack but before the turn ended,
this silently cancelled the already-triggered extra turn.
- Stop resetting the shared flag from the return-to-hand handler; only
its own move-to-hand logic depends on the card still being in the
battle zone. Add regression tests, including one that destroys the
attacker mid-turn to cover the exact reported scenario.

## 🔧 Other Changes

- Added tests for Balesk Baj the Timerburner

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] Tests are written that covers the changes made and any bugs fixed (`./sim/tests`)

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it
