### PR TITLE
Fix Bombazar not losing when put into play off-turn

### DIFF
--- a/sim/game/cards/dm10/armored_dragon.go
+++ b/sim/game/cards/dm10/armored_dragon.go
@@ -65,12 +65,19 @@ func BombazarDragonOfDestiny(c *match.Card) {
 				ctx.Match.Destroy(creature, card, match.DestroyedByMiscAbility)
 			}
 
-			if !ctx.Match.IsPlayerTurn(card.Player) {
+			if ctx.Match.IsPlayerTurn(card.Player) {
+				extraTurnPending = true
+				ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s's effect: %s will take an extra turn and then lose the game at the end of it", card.Name, card.Player.Username()))
 				return
 			}
 
-			extraTurnPending = true
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s's effect: %s will take an extra turn and then lose the game at the end of it", card.Name, card.Player.Username()))
+			// Put into the battle zone on someone else's turn, for example by an
+			// effect that has its owner put it into play off-turn. "The turn
+			// after this one" is then the owner's own next turn, which already
+			// follows naturally, so no turn needs to be repeated: only the loss
+			// remains to be scheduled for the end of that turn.
+			loseAfterExtraTurn = true
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s's effect: %s will lose the game at the end of their next turn", card.Name, card.Player.Username()))
 		}),
 		func(card *match.Card, ctx *match.Context) {
 

--- a/sim/tests/cards/bombazar_dragon_of_destiny_test.go
+++ b/sim/tests/cards/bombazar_dragon_of_destiny_test.go
@@ -131,6 +131,29 @@ func TestBombazarDragonOfDestiny(t *testing.T) {
 		assert.Contains(t, headers, "duel_finished", "the opponent is told they won")
 	})
 
+	t.Run("entering play on another player's turn still loses at the end of the owner's next turn", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		require.True(t, scn.Match.IsPlayerTurn(player.Player))
+
+		// The owner's own Bombazar enters their battle zone (for example via
+		// an effect like Soulswap, cast by the active player) while it is
+		// not the owner's turn. "The turn after this one" is the owner's own
+		// next turn, which already follows naturally, so no turn is repeated.
+		bombazar := putCardInBattlezone(t, scn, opponent.Player, bombazarUID, bombazarSetupSrc)
+		require.NoError(t, scn.WaitForEventLoop())
+		require.Equal(t, match.BATTLEZONE, bombazar.Zone)
+		require.True(t, scn.Match.IsPlayerTurn(player.Player), "no extra turn is inserted for the active player")
+
+		require.NoError(t, scn.ActionEndTurn(player))
+		require.True(t, scn.Match.IsPlayerTurn(opponent.Player), "the owner's next turn arrives normally")
+
+		require.NoError(t, scn.ActionEndTurn(opponent))
+
+		require.Eventually(t, scn.Match.IsClosed, 2*time.Second, 10*time.Millisecond,
+			"the owner loses at the end of their next turn even though Bombazar entered play on the opponent's turn")
+	})
+
 	t.Run("only one extra turn is taken", func(t *testing.T) {
 		scn, player, _ := setupDuel(t)
 


### PR DESCRIPTION
## 📝 Summary

Fix Bombazar not losing when put into play off-turn

## 🎴 New Cards Added

-

## 🐞 Bugs Fixed

- The extra-turn/loss trigger bailed out entirely if it wasn't the owner's turn, so effects that force the owner to put Bombazar into their own battle zone on the opponent's turn (e.g. Soulswap) skipped the loss too.

## 🔧 Other Changes

-

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] Tests are written that covers the changes made and any bugs fixed (`./sim/tests`)

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it
