### PR TITLE
UI bugs -- cards slider under graveyard and shields number in attack player pop-up

### DIFF
--- a/packages/duel-interface/Action.tsx
+++ b/packages/duel-interface/Action.tsx
@@ -21,6 +21,8 @@ export interface ActionProps {
   actionType?: ActionType;
   cards?: CardState[];
   cardsObject?: Record<string, CardState[]>;
+  /** virtualId -> shield number, as shown in the shield zone. */
+  shieldMap?: Record<string, number>;
   showCards?: {
     cards: string[];
     dismissable: boolean;
@@ -40,6 +42,7 @@ export function Action({
   cards,
   unselectableCards,
   cardsObject,
+  shieldMap,
   showCards,
   cancellable,
   visible,
@@ -247,7 +250,7 @@ export function Action({
                   selectedCardsObjectCards.map((card) => (
                     <div
                       key={card.virtualId}
-                      className="w-full"
+                      className="relative w-full"
                       data-card-id={card.virtualId}
                       onPointerEnter={() => handleCardHover(card.virtualId)}
                       onPointerDown={() => handleCardPointerDown(card.virtualId)}
@@ -270,6 +273,7 @@ export function Action({
                         alt={card.name}
                         style={{ borderRadius: "5%" }}
                       />
+                      <ShieldNumber shieldMap={shieldMap} card={card} />
                     </div>
                   ))}
 
@@ -281,7 +285,7 @@ export function Action({
                   cards?.map((card) => (
                     <div
                       key={card.virtualId}
-                      className="w-full"
+                      className="relative w-full"
                       data-card-id={card.virtualId}
                       onPointerEnter={() => handleCardHover(card.virtualId)}
                       onPointerDown={() => handleCardPointerDown(card.virtualId)}
@@ -304,12 +308,13 @@ export function Action({
                         alt={card.name}
                         style={{ borderRadius: "5%" }}
                       />
+                      <ShieldNumber shieldMap={shieldMap} card={card} />
                     </div>
                   ))}
 
                 {!cardsObject &&
                   unselectableCards?.map((card) => (
-                    <div key={card.virtualId} className="w-full">
+                    <div key={card.virtualId} className="relative w-full">
                       <img
                         onContextMenu={(event) => {
                           event.preventDefault();
@@ -323,6 +328,7 @@ export function Action({
                         alt={card.name}
                         style={{ borderRadius: "5%" }}
                       />
+                      <ShieldNumber shieldMap={shieldMap} card={card} />
                     </div>
                   ))}
               </div>
@@ -519,5 +525,28 @@ export function Action({
         </div>
       </div>
     </Popup>
+  );
+}
+
+// ShieldNumber mirrors the badge the shield zone draws in Card.tsx, so a
+// shield offered as a selection candidate (for example when choosing which
+// one to break) keeps the same index the player already knows it by.
+function ShieldNumber({
+  shieldMap,
+  card,
+}: {
+  shieldMap?: Record<string, number>;
+  card: CardState;
+}) {
+  const number = shieldMap?.[card.virtualId];
+
+  if (number === undefined) {
+    return null;
+  }
+
+  return (
+    <span className="pointer-events-none absolute top-[2%] right-[10%] text-[clamp(0.55rem,1.1vh,0.8rem)] leading-none text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)]">
+      {number}
+    </span>
   );
 }

--- a/packages/duel-interface/Duel.tsx
+++ b/packages/duel-interface/Duel.tsx
@@ -938,7 +938,7 @@ export function Duel({
               <div className="absolute inset-0 bg-red-500/30 pointer-events-none z-20" />
             )}
             <div className="absolute inset-0 z-10 overflow-x-auto overflow-y-hidden">
-              <div className="inline-flex w-max justify-start gap-5 h-full pb-1">
+              <div className="inline-flex w-max justify-start gap-5 h-full pb-1 pr-[100px] min-[1200px]:pr-[180px]">
                 {state.opponent.manazone.map(
                   CreateCard({
                     flipped: !flipOpponentCards,
@@ -966,7 +966,7 @@ export function Duel({
               <div className="absolute inset-0 bg-red-500/30 pointer-events-none z-20" />
             )}
             <div className="absolute inset-0 z-10 overflow-x-auto overflow-y-hidden">
-              <div className="inline-flex w-max justify-start gap-5 h-full p-1">
+              <div className="inline-flex w-max justify-start gap-5 h-full p-1 pr-[100px] min-[1200px]:pr-[180px]">
                 {state.opponent.shieldzone.map(
                   CreateCard({
                     flipped: !flipOpponentCards,
@@ -995,7 +995,7 @@ export function Duel({
               <div className="absolute inset-0 bg-red-500/30 pointer-events-none z-20" />
             )}
             <div className="absolute inset-0 z-10 overflow-x-auto overflow-y-hidden">
-              <div className="inline-flex w-max justify-start gap-5 h-full p-1">
+              <div className="inline-flex w-max justify-start gap-5 h-full p-1 pr-[100px] min-[1200px]:pr-[180px]">
                 {state.opponent.playzone.map(
                   CreateCard({
                     flipped: !flipOpponentCards,
@@ -1017,7 +1017,7 @@ export function Duel({
               <div className="absolute inset-0 bg-red-500/30 pointer-events-none z-20" />
             )}
             <div className="absolute inset-0 z-10 overflow-x-auto overflow-y-hidden">
-              <div className="inline-flex w-max justify-start gap-5 h-full p-1">
+              <div className="inline-flex w-max justify-start gap-5 h-full p-1 pr-[100px] min-[1200px]:pr-[180px]">
                 {state.me.playzone.map(
                   CreateCard({
                     selected: (id: string) => id === selectedCardId,
@@ -1045,7 +1045,7 @@ export function Duel({
               <div className="absolute inset-0 bg-red-500/30 pointer-events-none z-20" />
             )}
             <div className="absolute inset-0 z-10 overflow-x-auto overflow-y-hidden">
-              <div className="inline-flex w-max justify-start gap-5 h-full p-1">
+              <div className="inline-flex w-max justify-start gap-5 h-full p-1 pr-[100px] min-[1200px]:pr-[180px]">
                 {state.me.shieldzone.map(
                   CreateCard({
                     shieldMap: state.me.shieldMap,
@@ -1067,7 +1067,7 @@ export function Duel({
               <div className="absolute inset-0 bg-red-500/30 pointer-events-none z-20" />
             )}
             <div className="absolute inset-0 z-10 overflow-x-auto overflow-y-hidden">
-              <div className="inline-flex w-max justify-start gap-5 h-full p-1">
+              <div className="inline-flex w-max justify-start gap-5 h-full p-1 pr-[100px] min-[1200px]:pr-[180px]">
                 {state.me.manazone.map(
                   CreateCard({
                     flipped: true,
@@ -1102,7 +1102,7 @@ export function Duel({
               <>
                 <div className="absolute inset-0 z-0" data-dropzone="hand" />
                 <div className="absolute inset-0 z-10 overflow-x-auto overflow-y-hidden">
-                  <div className="inline-flex w-max justify-start gap-5 h-full pt-1 p-px">
+                  <div className="inline-flex w-max justify-start gap-5 h-full pt-1 p-px pr-[100px] min-[1200px]:pr-[180px]">
                     {state.me.hand.map(
                       CreateCard({
                         selected: (id: string) => id === selectedCardId,
@@ -1508,6 +1508,7 @@ export function Duel({
               ? action.cards
               : undefined
           }
+          shieldMap={{ ...state.opponent.shieldMap, ...state.me.shieldMap }}
           showCards={action.showCards}
           text={action.text}
           minSelections={action.minSelections || 0}


### PR DESCRIPTION
## 📝 Summary

UI bugs

## 🎴 New Cards Added

-

## 🐞 Bugs Fixed

- 1. Resolved slider not reaching last card under the graveyard when having more cards than the width of the screen in the battlezone.

- 2. Show shield numbers in the attack/selection popup.

## 🔧 Other Changes

-

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [ ] Tests are written that covers the changes made and any bugs fixed (`./sim/tests`)

## 📸 Screenshots (if applicable)

<img width="977" height="332" alt="Screenshot 2026-08-16 154528" src="https://github.com/user-attachments/assets/8bc749ec-9d6f-4e34-ad1a-48052d6d7629" />
<img width="952" height="337" alt="Screenshot 2026-08-16 154609" src="https://github.com/user-attachments/assets/67500d54-2dd4-47f6-9ef8-bffbc499b95d" />
<img width="968" height="313" alt="Screenshot 2026-08-16 154640" src="https://github.com/user-attachments/assets/24efc183-bd8b-4e5c-a464-99cee3d00e3b" />
<img width="969" height="327" alt="Screenshot 2026-08-16 154654" src="https://github.com/user-attachments/assets/8a7747e6-ef70-4007-9c2b-eb56be41c143" />
<img width="629" height="321" alt="Screenshot 2026-08-16 155011" src="https://github.com/user-attachments/assets/62d90941-d0fb-4249-81f2-7e4b2a4dbeb5" />
<img width="500" height="470" alt="Screenshot 2026-08-16 155027" src="https://github.com/user-attachments/assets/f35fae45-9e44-4fc1-b10b-9ef5e9d6c059" />

