### PR TITLE
New card: Meloppe + lots of helper methods needed

### DIFF
--- a/sim/game/cards/dm02/spells.go
+++ b/sim/game/cards/dm02/spells.go
@@ -6,6 +6,7 @@ import (
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
 	"fmt"
+	"strings"
 )
 
 // BurstShot ...
@@ -98,28 +99,44 @@ func ReconOperation(c *match.Card) {
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
 
+		opponent := ctx.Match.Opponent(card.Player)
+		chooser := fx.ResolveShieldChooser(ctx, card.Player, opponent)
+
 		shields := fx.SelectBackside(
-			card.Player,
+			chooser,
 			ctx.Match,
-			ctx.Match.Opponent(card.Player),
+			opponent,
 			match.SHIELDZONE,
-			"Recon Operation: Select 3 of your opponent's shields that will be shown to you",
+			fmt.Sprintf("Recon Operation: Select 3 of %s shields that will be shown to you%s", fx.ShieldPossessive(chooser, opponent), fx.MeloppeNote(chooser, card.Player)),
 			1,
 			3,
 			true,
 		)
 
-		ids := make([]string, 0)
+		if len(shields) < 1 {
+			return
+		}
+
+		// Grabbed before the pop-up so the numbers still match: whoever picked
+		// these shields (their own owner, if Meloppe redirected) never sees this
+		// reveal, so it's the only way card.Player can tell them which shields
+		// they were.
+		ids := make([]string, 0, len(shields))
+		descriptions := make([]string, 0, len(shields))
 
 		for _, s := range shields {
 			ids = append(ids, s.ImageID)
+			descriptions = append(descriptions, fx.DescribeShield(s))
 		}
+
+		joined := strings.Join(descriptions, ", ")
 
 		ctx.Match.ShowCards(
 			card.Player,
-			"Your opponent's shields:",
+			fmt.Sprintf("Your opponent's %s:", joined),
 			ids,
 		)
+		ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s of %s was shown to %s", joined, opponent.Username(), card.Player.Username()))
 
 	}))
 

--- a/sim/game/cards/dm06/light_bringer.go
+++ b/sim/game/cards/dm06/light_bringer.go
@@ -5,6 +5,7 @@ import (
 	"duel-masters/game/family"
 	"duel-masters/game/fx"
 	"duel-masters/game/match"
+	"fmt"
 )
 
 func VessTheOracle(c *match.Card) {
@@ -67,7 +68,7 @@ func AdomisTheOracle(c *match.Card) {
 		cards["Your shields"] = fx.Find(c.Player, match.SHIELDZONE)
 		cards["Opponent's shields"] = fx.Find(ctx.Match.Opponent(c.Player), match.SHIELDZONE)
 
-		fx.SelectMultipartBackside(
+		picked := fx.SelectMultipartBackside(
 			card.Player,
 			ctx.Match,
 			cards,
@@ -75,12 +76,24 @@ func AdomisTheOracle(c *match.Card) {
 			1,
 			1,
 			true,
-		).Map(func(x *match.Card) {
+		)
+
+		// A blind pick that landed on the opponent's shields may still belong to
+		// them to choose instead (e.g. Meloppe): nothing about it was revealed
+		// yet, so swapping it out here is safe.
+		fx.ResolveShieldChoices(ctx, card.Player, picked).Map(func(x *match.Card) {
+			// Grabbed before the pop-up so the number still matches: whoever
+			// picked x (its own owner, if Meloppe redirected) never sees this
+			// reveal, so it's the only way card.Player can tell them which shield
+			// it was.
+			description := fx.DescribeShield(x)
+
 			ctx.Match.ShowCards(
 				card.Player,
-				"The shield is:",
+				fmt.Sprintf("The %s is:", description),
 				[]string{x.ImageID},
 			)
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s of %s was shown to %s", description, x.Player.Username(), card.Player.Username()))
 		})
 
 	}

--- a/sim/game/cards/dm06/spells.go
+++ b/sim/game/cards/dm06/spells.go
@@ -103,12 +103,15 @@ func InvincibleCataclysm(c *match.Card) {
 	c.ManaRequirement = []string{civ.Fire}
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
+		opponent := ctx.Match.Opponent(card.Player)
+		chooser := fx.ResolveShieldChooser(ctx, card.Player, opponent)
+
 		fx.SelectBackside(
-			card.Player,
+			chooser,
 			ctx.Match,
-			ctx.Match.Opponent(card.Player),
+			opponent,
 			match.SHIELDZONE,
-			fmt.Sprintf("%s: Select up to 3 of your opponent's shields and send them to graveyard", card.Name),
+			fmt.Sprintf("%s: Select up to 3 of %s shields and send them to graveyard%s", card.Name, fx.ShieldPossessive(chooser, opponent), fx.MeloppeNote(chooser, card.Player)),
 			1,
 			3,
 			true,

--- a/sim/game/cards/dm09/aqua_master.go
+++ b/sim/game/cards/dm09/aqua_master.go
@@ -21,19 +21,35 @@ func AquaMaster(c *match.Card) {
 	c.Use(fx.Creature, fx.ShieldsSelectionEffect,
 		fx.When(fx.WheneverThisAttacksPlayerAndIsntBlocked,
 			func(card *match.Card, ctx *match.Context) {
+				opponent := ctx.Match.Opponent(card.Player)
+
+				// A persistent effect (e.g. Meloppe) may override who chooses the
+				// shield via the SelectShields event's Chooser field, same as the
+				// default shield-break selection in fx.Creature.
+				chooser := card.Player
+				if event, ok := ctx.Event.(*match.SelectShields); ok && event.Chooser != nil {
+					chooser = event.Chooser
+				}
+
 				fx.SelectBackside(
-					card.Player,
+					chooser,
 					ctx.Match,
-					ctx.Match.Opponent(card.Player),
+					opponent,
 					match.SHIELDZONE,
-					fmt.Sprintf("%s's effect: Choose one of your opponent's shield and turn it face up.", card.Name),
+					fmt.Sprintf("%s's effect: Choose one of %s shield and turn it face up.%s", card.Name, fx.ShieldPossessive(chooser, opponent), fx.MeloppeNote(chooser, card.Player)),
 					1,
 					1,
 					false,
 				).Map(func(x *match.Card) {
+					// Grabbed before it's flipped face up: not that it matters here
+					// since the shield stays put, but it keeps this consistent with
+					// every other reveal that has to grab it before the shield can
+					// move or change.
+					description := fx.DescribeShield(x)
+
 					x.ShieldFaceUp = true
 					ctx.Match.BroadcastState()
-					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was turned face up from %s's shieldzone.", x.Name, ctx.Match.Opponent(card.Player).Username()))
+					ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was turned face up from %s's shieldzone.", description, opponent.Username()))
 				})
 			}))
 }

--- a/sim/game/cards/dm12/angel_command.go
+++ b/sim/game/cards/dm12/angel_command.go
@@ -100,9 +100,19 @@ func UlarusPunishmentElemental(c *match.Card) {
 			true,
 		)
 
+		// Whichever of those blindly landed on the opponent's shields may still
+		// belong to them to choose instead (e.g. Meloppe): nothing about the pick
+		// was revealed yet, so swapping it out here is safe.
+		turned = fx.ResolveShieldChoices(ctx, card.Player, turned)
+
 		turned.Map(func(shield *match.Card) {
+			// Grabbed before it's flipped face up: not that it matters here since
+			// the shield stays put, but it keeps this consistent with every other
+			// reveal that has to grab it before the shield can move or change.
+			description := fx.DescribeShield(shield)
+
 			shield.ShieldFaceUp = true
-			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("A shield of %s was turned face up by %s", shield.Player.Username(), card.Name))
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s of %s was turned face up by %s", description, shield.Player.Username(), card.Name))
 		})
 
 		if len(turned) > 0 {

--- a/sim/game/cards/dm12/cyber_lord.go
+++ b/sim/game/cards/dm12/cyber_lord.go
@@ -17,11 +17,17 @@ func Meloppe(c *match.Card) {
 	c.ManaCost = 3
 	c.ManaRequirement = []string{civ.Water}
 
+	// Both of Meloppe's clauses reduce to the same rule regardless of which
+	// side controls it: while Meloppe is in play, a card's own owner always
+	// picks which of their own face-down shields is chosen, instead of
+	// whoever the effect's default chooser would otherwise be.
+	//
 	// Breaking shields always has the attacker pick which of the defender's
-	// face-down shields come off (see SelectAndReturnShields), so both of
-	// Meloppe's clauses reduce to the same rule regardless of which side
-	// controls it: while Meloppe is in play, the shield owner picks their own
-	// shields instead of the attacker picking for them.
+	// face-down shields come off (see SelectAndReturnShields), so that case is
+	// handled through SelectShields.Chooser. Every other "choose one of a
+	// player's shields" effect (looking at one, discarding one, and so on)
+	// goes through ChooseShieldEvent instead (see fx.ResolveShieldChooser), so
+	// this same effect intercepts both.
 	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
 		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
 			if card.Zone != match.BATTLEZONE {
@@ -29,12 +35,12 @@ func Meloppe(c *match.Card) {
 				return
 			}
 
-			event, ok := ctx2.Event.(*match.SelectShields)
-			if !ok {
-				return
+			switch event := ctx2.Event.(type) {
+			case *match.SelectShields:
+				event.Chooser = ctx2.Match.Opponent(event.Attacker.Player)
+			case *match.ChooseShieldEvent:
+				event.Chooser = event.ShieldOwner
 			}
-
-			event.Chooser = ctx2.Match.Opponent(event.Attacker.Player)
 		})
 	}))
 

--- a/sim/game/cards/dm12/cyber_lord.go
+++ b/sim/game/cards/dm12/cyber_lord.go
@@ -1,0 +1,41 @@
+package dm12
+
+import (
+	"duel-masters/game/civ"
+	"duel-masters/game/family"
+	"duel-masters/game/fx"
+	"duel-masters/game/match"
+)
+
+// Meloppe ...
+func Meloppe(c *match.Card) {
+
+	c.Name = "Meloppe"
+	c.Power = 1000
+	c.Civs = []string{civ.Water}
+	c.Family = []string{family.CyberLord}
+	c.ManaCost = 3
+	c.ManaRequirement = []string{civ.Water}
+
+	// Breaking shields always has the attacker pick which of the defender's
+	// face-down shields come off (see SelectAndReturnShields), so both of
+	// Meloppe's clauses reduce to the same rule regardless of which side
+	// controls it: while Meloppe is in play, the shield owner picks their own
+	// shields instead of the attacker picking for them.
+	c.Use(fx.Creature, fx.When(fx.InTheBattlezone, func(card *match.Card, ctx *match.Context) {
+		ctx.Match.ApplyPersistentEffect(func(ctx2 *match.Context, exit func()) {
+			if card.Zone != match.BATTLEZONE {
+				exit()
+				return
+			}
+
+			event, ok := ctx2.Event.(*match.SelectShields)
+			if !ok {
+				return
+			}
+
+			event.Chooser = ctx2.Match.Opponent(event.Attacker.Player)
+		})
+	}))
+
+}

--- a/sim/game/cards/dm12/spells.go
+++ b/sim/game/cards/dm12/spells.go
@@ -199,12 +199,15 @@ func CosmicDarts(c *match.Card) {
 	c.ManaRequirement = []string{civ.Light}
 
 	c.Use(fx.Spell, fx.When(fx.SpellCast, func(card *match.Card, ctx *match.Context) {
+		opponent := ctx.Match.Opponent(card.Player)
+		chooser := fx.ResolveShieldChooser(ctx, opponent, card.Player)
+
 		shields := fx.SelectBackside(
-			ctx.Match.Opponent(card.Player),
+			chooser,
 			ctx.Match,
 			card.Player,
 			match.SHIELDZONE,
-			fmt.Sprintf("%s: Choose one of your opponent's shields", card.Name),
+			fmt.Sprintf("%s: Choose one of %s shields%s", card.Name, fx.ShieldPossessive(chooser, card.Player), fx.MeloppeNote(chooser, opponent)),
 			1,
 			1,
 			false,
@@ -216,15 +219,22 @@ func CosmicDarts(c *match.Card) {
 
 		shield := shields[0]
 
+		// Grabbed before either pop-up so the number still matches: whoever
+		// picked shield (the opponent, unless Meloppe redirected) never sees
+		// this reveal, so it's the only way card.Player can tell them which
+		// shield it was.
+		description := fx.DescribeShield(shield)
+		ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s was shown to %s", description, card.Player.Username()))
+
 		if !shield.HasCondition(cnd.Spell) {
-			ctx.Match.ShowCards(card.Player, fmt.Sprintf("%s: Your shield", card.Name), []string{shield.ImageID})
+			ctx.Match.ShowCards(card.Player, fmt.Sprintf("%s: Your %s", card.Name, description), []string{shield.ImageID})
 			return
 		}
 
 		// Non-dismissible so the caster actually sees the revealed spell before
 		// being asked whether to cast it, instead of the preview being raced by
 		// the immediately-following prompt.
-		ctx.Match.ShowCardsNonDismissible(card.Player, fmt.Sprintf("%s: Your shield", card.Name), []string{shield.ImageID})
+		ctx.Match.ShowCardsNonDismissible(card.Player, fmt.Sprintf("%s: Your %s", card.Name, description), []string{shield.ImageID})
 
 		if !fx.BinaryQuestion(card.Player, ctx.Match, fmt.Sprintf("%s: You may cast %s immediately for no cost", card.Name, shield.Name)) {
 			return

--- a/sim/game/cards/repository.go
+++ b/sim/game/cards/repository.go
@@ -958,6 +958,7 @@ var DM12 = map[string]match.CardConstructor{
 	"05c5496d-e5fa-4691-8542-2d6c6919f402": dm12.UlarusPunishmentElemental,
 	"76310adb-f7c2-4545-8b71-2332b36fbb83": dm12.Gigavrand,
 	"0fe53ab5-bef9-4bbd-bb05-c94ccb9b1342": dm12.CosmicDarts,
+	"0451a36e-fe88-4817-ad94-3dbd9e460fb8": dm12.Meloppe,
 }
 
 // Promo is a map with all the card id's in the game and corresponding CardConstructor for promotional exclusive cards

--- a/sim/game/fx/common_effects.go
+++ b/sim/game/fx/common_effects.go
@@ -5,6 +5,7 @@ import (
 	"duel-masters/game/match"
 	"fmt"
 	"math/rand"
+	"strings"
 )
 
 func GiveTapAbilityToAllies(card *match.Card, ctx *match.Context, alliesFilter func(card *match.Card) bool, tapAbility func(card *match.Card, ctx *match.Context)) {
@@ -180,6 +181,132 @@ func HaveSelfConditionsWhenNoShields(card *match.Card, ctx *match.Context, condi
 	})
 }
 
+// ResolveShieldChooser returns who should be prompted to choose a face-down
+// card out of shieldOwner's shield zone, honoring a persistent effect (e.g.
+// Meloppe) that redirects a cross-player shield choice back to the shield's
+// own owner.
+//
+// Choosing your own shields is never redirected, so callers that already pass
+// the shield owner as the chooser can skip this and call SelectBackside
+// directly; there is nothing for a persistent effect to reverse there.
+func ResolveShieldChooser(ctx *match.Context, defaultChooser *match.Player, shieldOwner *match.Player) *match.Player {
+	if defaultChooser == shieldOwner {
+		return defaultChooser
+	}
+
+	event := &match.ChooseShieldEvent{ShieldOwner: shieldOwner, Chooser: defaultChooser}
+	ctx.Match.HandleFx(match.NewContext(ctx.Match, event))
+
+	return event.Chooser
+}
+
+// ResolveShieldChoices re-delegates the picks of a combined, owner-agnostic
+// shield selection (an effect naming no specific owner, such as "choose a
+// shield") already made blind, for any pick that landed on someone other
+// than defaultChooser and that a persistent effect (e.g. Meloppe) says its
+// owner should have chosen instead.
+//
+// defaultChooser's own picks are returned unchanged, since there is nothing
+// to reverse when the chooser already owns the shield. Everything else is
+// grouped by owner; an owner Meloppe redirects to themselves gets a fresh,
+// mandatory backside pick of the same count from their own shield zone,
+// replacing what the original chooser blindly landed on. Nothing about that
+// original pick was ever revealed to the chooser, so swapping it out here
+// leaks no information.
+func ResolveShieldChoices(ctx *match.Context, defaultChooser *match.Player, picks CardCollection) CardCollection {
+	result := make(CardCollection, 0, len(picks))
+
+	byOwner := make(map[*match.Player][]*match.Card)
+	for _, card := range picks {
+		if card.Player == defaultChooser {
+			result = append(result, card)
+			continue
+		}
+
+		byOwner[card.Player] = append(byOwner[card.Player], card)
+	}
+
+	for owner, owned := range byOwner {
+		chooser := ResolveShieldChooser(ctx, defaultChooser, owner)
+		if chooser == defaultChooser {
+			result = append(result, owned...)
+			continue
+		}
+
+		replaced := SelectBackside(
+			chooser,
+			ctx.Match,
+			owner,
+			match.SHIELDZONE,
+			fmt.Sprintf("Meloppe's effect: Choose %d of your shields instead.", len(owned)),
+			len(owned),
+			len(owned),
+			false,
+		)
+
+		result = append(result, replaced...)
+	}
+
+	return result
+}
+
+// ShieldPossessive phrases a prompt about shieldOwner's shield zone from
+// chooser's point of view, so a chooser Meloppe redirected onto their own
+// shields reads "your shields" instead of a stale "your opponent's shields"
+// that assumed the default chooser.
+func ShieldPossessive(chooser *match.Player, shieldOwner *match.Player) string {
+	if chooser == shieldOwner {
+		return "your"
+	}
+
+	return "your opponent's"
+}
+
+// MeloppeNote returns a parenthetical to append to a shield-choice prompt
+// when chooser isn't the effect's usual chooser, so a player unfamiliar with
+// Meloppe isn't left wondering why they're the one being asked. Hardcoded to
+// name Meloppe: it is currently the only effect that reverses who chooses a
+// shield, so there is nothing more general to say here.
+func MeloppeNote(chooser *match.Player, defaultChooser *match.Player) string {
+	if chooser == defaultChooser {
+		return ""
+	}
+
+	return " (Meloppe's effect: you choose instead of your opponent.)"
+}
+
+// ShieldNumber returns a shield's 1-based position in its owner's shield
+// zone, the same order the owner sees their own face-down shields numbered
+// in. Call it before the shield moves out of that zone: a card that has
+// already broken, been discarded, or otherwise left the shield zone can no
+// longer be found there, and this returns 0.
+//
+// A player shown a shield's identity without having picked it themselves
+// (e.g. Meloppe redirected who chose) has no other way to know which one it
+// was, since nobody but the shield's owner ever sees that pick happen.
+func ShieldNumber(shield *match.Card) int {
+	shields, err := shield.Player.Container(match.SHIELDZONE)
+	if err != nil {
+		return 0
+	}
+
+	for i, s := range shields {
+		if s.ID == shield.ID {
+			return i + 1
+		}
+	}
+
+	return 0
+}
+
+// DescribeShield labels a shield with its owner-relative position and name,
+// e.g. "shield #2 (Aqua Surfer)", for a message about a shield shown to
+// someone other than its owner. Call it before the shield moves out of its
+// shield zone; see ShieldNumber.
+func DescribeShield(shield *match.Card) string {
+	return fmt.Sprintf("shield #%d (%s)", ShieldNumber(shield), shield.Name)
+}
+
 func RotateShields(card *match.Card, ctx *match.Context, max int) {
 
 	nrShields, err := card.Player.Container(match.SHIELDZONE)
@@ -242,13 +369,14 @@ func DestroyOpShield(card *match.Card, ctx *match.Context) {
 func BreakXOpShields(x int) match.HandlerFunc {
 	return func(card *match.Card, ctx *match.Context) {
 		opponent := ctx.Match.Opponent(card.Player)
+		chooser := ResolveShieldChooser(ctx, card.Player, opponent)
 
 		shields := SelectBackside(
-			card.Player,
+			chooser,
 			ctx.Match,
 			opponent,
 			match.SHIELDZONE,
-			fmt.Sprintf("%s effect: select %d shield(s) to break", card.Name, x),
+			fmt.Sprintf("%s effect: select %d shield(s) to break%s", card.Name, x, MeloppeNote(chooser, card.Player)),
 			x,
 			x,
 			false,
@@ -271,13 +399,14 @@ func BreakXOpShields(x int) match.HandlerFunc {
 // go to the opponent's hand and its shield trigger is not offered.
 func PutOpShieldIntoGraveyard(card *match.Card, ctx *match.Context) {
 	opponent := ctx.Match.Opponent(card.Player)
+	chooser := ResolveShieldChooser(ctx, card.Player, opponent)
 
 	SelectBackside(
-		card.Player,
+		chooser,
 		ctx.Match,
 		opponent,
 		match.SHIELDZONE,
-		fmt.Sprintf("%s's effect: Choose one of your opponent's shields and put it into their graveyard.", card.Name),
+		fmt.Sprintf("%s's effect: Choose one of %s shields and put it into their graveyard.%s", card.Name, ShieldPossessive(chooser, opponent), MeloppeNote(chooser, card.Player)),
 		1,
 		1,
 		false,
@@ -324,18 +453,26 @@ func ShowXShields(x int, cancellable bool) match.HandlerFunc {
 	return func(card *match.Card, ctx *match.Context) {
 
 		shieldsID := []string{}
+		descriptions := []string{}
+		opponent := ctx.Match.Opponent(card.Player)
+		chooser := ResolveShieldChooser(ctx, card.Player, opponent)
 
 		SelectBackside(
-			card.Player,
+			chooser,
 			ctx.Match,
-			ctx.Match.Opponent(card.Player),
+			opponent,
 			match.SHIELDZONE,
-			fmt.Sprintf("%s: Select %d of your opponent's shields that will be shown to you", card.Name, x),
+			fmt.Sprintf("%s: Select %d of %s shields that will be shown to you%s", card.Name, x, ShieldPossessive(chooser, opponent), MeloppeNote(chooser, card.Player)),
 			1,
 			x,
 			cancellable,
-		).Map(func(shields *match.Card) {
-			shieldsID = append(shieldsID, shields.ImageID)
+		).Map(func(shield *match.Card) {
+			// Grabbed before the pop-up so the numbers still match: whoever
+			// picked shield (its own owner, if Meloppe redirected) never sees
+			// this reveal, so it's the only way card.Player can tell them which
+			// shields they were.
+			shieldsID = append(shieldsID, shield.ImageID)
+			descriptions = append(descriptions, DescribeShield(shield))
 		})
 
 		// Nothing was chosen, either because the opponent has no shields or
@@ -346,9 +483,10 @@ func ShowXShields(x int, cancellable bool) match.HandlerFunc {
 
 		ctx.Match.ShowCards(
 			card.Player,
-			"Your opponent's shield:",
+			fmt.Sprintf("Your opponent's %s:", strings.Join(descriptions, ", ")),
 			shieldsID,
 		)
+		ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s of %s was shown to %s", strings.Join(descriptions, ", "), opponent.Username(), card.Player.Username()))
 	}
 
 }

--- a/sim/game/fx/creature.go
+++ b/sim/game/fx/creature.go
@@ -462,10 +462,19 @@ func Creature(card *match.Card, ctx *match.Context) {
 		}
 
 		ctx.ScheduleAfter(func() {
+			chooser := card.Player
+			cancellable := event.Cancellable
+
+			if event.Chooser != nil {
+				chooser = event.Chooser
+				cancellable = false
+			}
+
 			shieldsAttacked := SelectAndReturnShields(
 				card,
+				chooser,
 				ctx,
-				event.Cancellable,
+				cancellable,
 			)
 
 			event.ShieldsAttacked = shieldsAttacked
@@ -676,7 +685,7 @@ func HasSummoningSickness(card *match.Card) bool {
 	return card.HasCondition(cnd.SummoningSickness) && !card.HasCondition(cnd.SpeedAttacker)
 }
 
-func SelectAndReturnShields(card *match.Card, ctx *match.Context, cancellable bool) []*match.Card {
+func SelectAndReturnShields(card *match.Card, chooser *match.Player, ctx *match.Context, cancellable bool) []*match.Card {
 	opponent := ctx.Match.Opponent(card.Player)
 	shieldzone, err := opponent.Container(match.SHIELDZONE)
 
@@ -710,19 +719,24 @@ func SelectAndReturnShields(card *match.Card, ctx *match.Context, cancellable bo
 
 	shieldsAttacked := make([]*match.Card, 0)
 
-	ctx.Match.NewBacksideAction(card.Player, shieldzone, noOfShields, noOfShields, fmt.Sprintf("Select %v shield(s) to break", noOfShields), cancellable)
+	ctx.Match.NewBacksideAction(chooser, shieldzone, noOfShields, noOfShields, fmt.Sprintf("Select %v shield(s) to break", noOfShields), cancellable)
+	defer ctx.Match.CloseAction(chooser)
+
+	if !ctx.Match.IsPlayerTurn(chooser) {
+		ctx.Match.Wait(ctx.Match.Opponent(chooser), "Waiting for your opponent to make an action")
+		defer ctx.Match.EndWait(ctx.Match.Opponent(chooser))
+	}
 
 	for {
-		action := card.Player.NextAction()
+		action := chooser.NextAction()
 
-		if action.Cancel {
+		if cancellable && action.Cancel {
 			ctx.InterruptFlow()
-			ctx.Match.CloseAction(card.Player)
 			return []*match.Card{}
 		}
 
 		if len(action.Cards) != noOfShields || !match.AssertCardsIn(shieldzone, action.Cards[0]) {
-			ctx.Match.ActionWarning(card.Player, "Your selection of cards does not fulfill the requirements")
+			ctx.Match.ActionWarning(chooser, "Your selection of cards does not fulfill the requirements")
 			continue
 		}
 
@@ -734,8 +748,6 @@ func SelectAndReturnShields(card *match.Card, ctx *match.Context, cancellable bo
 			}
 			shieldsAttacked = append(shieldsAttacked, shield)
 		}
-
-		ctx.Match.CloseAction(card.Player)
 
 		return shieldsAttacked
 	}

--- a/sim/game/fx/creature.go
+++ b/sim/game/fx/creature.go
@@ -719,7 +719,7 @@ func SelectAndReturnShields(card *match.Card, chooser *match.Player, ctx *match.
 
 	shieldsAttacked := make([]*match.Card, 0)
 
-	ctx.Match.NewBacksideAction(chooser, shieldzone, noOfShields, noOfShields, fmt.Sprintf("Select %v shield(s) to break", noOfShields), cancellable)
+	ctx.Match.NewBacksideAction(chooser, shieldzone, noOfShields, noOfShields, fmt.Sprintf("Select %v shield(s) to break%s", noOfShields, MeloppeNote(chooser, card.Player)), cancellable)
 	defer ctx.Match.CloseAction(chooser)
 
 	if !ctx.Match.IsPlayerTurn(chooser) {

--- a/sim/game/fx/whenever_this_attacks.go
+++ b/sim/game/fx/whenever_this_attacks.go
@@ -51,26 +51,40 @@ func LookAtOppShields(card *match.Card, ctx *match.Context) {
 
 func WheneverThisAttacksMayLookAtOpShield() match.HandlerFunc {
 	return When(AttackConfirmed, func(card *match.Card, ctx *match.Context) {
+		opponent := ctx.Match.Opponent(card.Player)
+		chooser := ResolveShieldChooser(ctx, card.Player, opponent)
+
 		SelectBackside(
-			card.Player,
+			chooser,
 			ctx.Match,
-			ctx.Match.Opponent(card.Player),
+			opponent,
 			match.SHIELDZONE,
-			fmt.Sprintf("%s: You may select 1 of your opponent's shields that will be shown to you", card.Name),
+			fmt.Sprintf("%s: You may select 1 of %s shields that will be shown to you%s", card.Name, ShieldPossessive(chooser, opponent), MeloppeNote(chooser, card.Player)),
 			1,
 			1,
 			true,
 		).Map(func(x *match.Card) {
+			// Grabbed before the pop-up so the number still matches: whoever
+			// picked x (its own owner, if Meloppe redirected) never sees this
+			// reveal, so it's the only way card.Player can tell them which
+			// shield it was.
+			description := DescribeShield(x)
+
+			// Reported before the pop-up, which can block on the attacker
+			// dismissing it: the defender who picked shouldn't have to wait on
+			// that to find out what happened.
+			ctx.Match.ReportActionInChat(card.Player, fmt.Sprintf("%s of %s was shown to %s", description, opponent.Username(), card.Player.Username()))
+
 			if ev, ok := ctx.Event.(*match.AttackConfirmed); ok && ev.Player {
 				ctx.Match.ShowCardsNonDismissible(
 					card.Player,
-					"Your opponent's shield:",
+					fmt.Sprintf("Your opponent's %s:", description),
 					[]string{x.ImageID},
 				)
 			} else {
 				ctx.Match.ShowCards(
 					card.Player,
-					"Your opponent's shield:",
+					fmt.Sprintf("Your opponent's %s:", description),
 					[]string{x.ImageID},
 				)
 			}

--- a/sim/game/match/events.go
+++ b/sim/game/match/events.go
@@ -140,6 +140,20 @@ type SelectShields struct {
 	ShieldsAttacked []*Card // Will be populated AFTER the Event is handled (player prompted to choose shields)
 }
 
+// ChooseShieldEvent is fired immediately before a card lets one player choose
+// a face-down card out of a shield zone that belongs to someone else, outside
+// the attack/SelectShields flow (for example "put one of your opponent's
+// shields into their graveyard" or "look at one of your opponent's shields").
+// A persistent effect (e.g. Meloppe) may override Chooser before the prompt is
+// shown, the same way SelectShields.Chooser works for the shield-break
+// selection. Nothing needs to fire this for a player choosing their own
+// shields, since there is no "opponent chooses your shields" wrong to reverse
+// there.
+type ChooseShieldEvent struct {
+	ShieldOwner *Player
+	Chooser     *Player
+}
+
 // SelectBlockers is fired after the AttackConfirmed effects,
 // Here, blockers (both normal and conditional) are added into the blockers list
 // and cards that have conditional CantBeBlocked effects handles them.

--- a/sim/game/match/events.go
+++ b/sim/game/match/events.go
@@ -126,10 +126,17 @@ type AttackConfirmed struct {
 }
 
 // SelectShields is fired after the Attacker confirmed the AttackPlayer sequence
-// The opponent is prompted to select exactly NoOfShields from their Shieldzone
+// The Attacker's controller is prompted to select exactly NoOfShields from the
+// defending player's Shieldzone, unless Chooser is set.
 type SelectShields struct {
-	Attacker        *Card
-	Cancellable     bool
+	Attacker    *Card
+	Cancellable bool
+	// Chooser overrides who is prompted to pick the shields (normally the
+	// Attacker's controller). A persistent effect may set this before the
+	// prompt is shown; leave nil to keep the default chooser. A choice made
+	// by an overridden Chooser is never cancellable, since the attack itself
+	// is not theirs to call off.
+	Chooser         *Player
 	ShieldsAttacked []*Card // Will be populated AFTER the Event is handled (player prompted to choose shields)
 }
 

--- a/sim/tests/cards/cosmic_darts_test.go
+++ b/sim/tests/cards/cosmic_darts_test.go
@@ -70,6 +70,23 @@ func TestCosmicDarts(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, scn.SubmitAction(opponent, shields[0].ID))
 		require.NoError(t, scn.WaitForMessage(player, playerMsgStart, "show_cards_non_dismissible"))
+
+		// The opponent picked blind and never sees this preview, so the pop-up
+		// and chat message are the only way they can tell which shield (their
+		// only one, shield #1) the caster ended up looking at.
+		popups, err := scn.ShowCardsMessages(player, playerMsgStart)
+		require.NoError(t, err)
+		require.Len(t, popups, 1)
+		assert.Contains(t, popups[0], "shield #1")
+		assert.Contains(t, popups[0], shields[0].Name)
+
+		chats, err := scn.ChatMessages(player, playerMsgStart)
+		require.NoError(t, err)
+		require.Len(t, chats, 1)
+		assert.Contains(t, chats[0], "shield #1")
+		assert.Contains(t, chats[0], shields[0].Name)
+		assert.Contains(t, chats[0], player.Player.Username())
+
 		playerMsgStart, err = scn.MessageCount(player)
 		require.NoError(t, err)
 		require.NoError(t, scn.CancelAction(player)) // dismiss preview

--- a/sim/tests/cards/meloppe_test.go
+++ b/sim/tests/cards/meloppe_test.go
@@ -1,0 +1,160 @@
+package cards
+
+import (
+	"duel-masters/game/civ"
+	"duel-masters/game/cnd"
+	"duel-masters/game/family"
+	"duel-masters/game/match"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	meloppeUID      = "0451a36e-fe88-4817-ad94-3dbd9e460fb8"
+	meloppeSetupSrc = "meloppe_test_setup"
+
+	// meloppeVanillaAttackerUID is Lah, Purification Enforcer: a plain 5500
+	// power creature with no effects of its own, used as an attacker that
+	// isn't Meloppe itself.
+	meloppeVanillaAttackerUID = "0cc5279e-0a26-41a8-a2a5-f7711120b772"
+
+	// meloppeDoubleBreakerUID is Astrocomet Dragon: double breaker with no
+	// other effect, used to confirm the shield count survives the swap.
+	meloppeDoubleBreakerUID = "91db2302-6794-4aa4-b17b-6637d356e9ac"
+)
+
+func TestMeloppe(t *testing.T) {
+	t.Run("printed characteristics", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+		card := putCardInBattlezone(t, scn, player.Player, meloppeUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		assertPrinted(t, card, "Meloppe", 1000, 3, []string{civ.Water})
+		assert.True(t, card.HasFamily(family.CyberLord))
+	})
+
+	t.Run("defender chooses their own shields instead of the attacker", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		// The defender controls Meloppe; the attacker is an unrelated vanilla creature.
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		attacker := putCardInBattlezone(t, scn, player.Player, meloppeVanillaAttackerUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.NotEmpty(t, shields)
+
+		attackerStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		defenderStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		require.NoError(t, scn.ActionAttackPlayerAsync(player, attacker.ID))
+
+		action, err := scn.WaitForAction(opponent, defenderStart)
+		require.NoError(t, err, "expected the defender, not the attacker, to be prompted for shields")
+		assert.False(t, action.Cancellable, "a chooser Meloppe installed can't call off the attacker's attack")
+		assert.Equal(t, 1, action.MinSelections)
+		assert.Equal(t, 1, action.MaxSelections)
+		assert.Len(t, action.Cards, len(shields))
+
+		// The attacker never received a shield-selection prompt of their own,
+		// only the "waiting for your opponent" notice.
+		attackerHeaders, err := scn.MessageHeaders(player, attackerStart)
+		require.NoError(t, err)
+		assert.NotContains(t, attackerHeaders, "action")
+
+		chosen := shields[0]
+		require.NoError(t, scn.SubmitAction(opponent, chosen.ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		assert.Equal(t, match.HAND, chosen.Zone)
+	})
+
+	t.Run("attacking with Meloppe itself still leaves the choice to its opponent", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		meloppe := putCardInBattlezone(t, scn, player.Player, meloppeUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.NotEmpty(t, shields)
+
+		defenderStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		require.NoError(t, scn.ActionAttackPlayerAsync(player, meloppe.ID))
+
+		action, err := scn.WaitForAction(opponent, defenderStart)
+		require.NoError(t, err, "expected the defender to be prompted even though they don't control Meloppe")
+		assert.False(t, action.Cancellable)
+
+		chosen := shields[0]
+		require.NoError(t, scn.SubmitAction(opponent, chosen.ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		assert.Equal(t, match.HAND, chosen.Zone)
+	})
+
+	t.Run("double breaker still asks the defender for two shields", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		attacker := putCardInBattlezone(t, scn, player.Player, meloppeDoubleBreakerUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(shields), 2)
+		require.True(t, attacker.HasCondition(cnd.DoubleBreaker))
+
+		defenderStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		require.NoError(t, scn.ActionAttackPlayerAsync(player, attacker.ID))
+
+		action, err := scn.WaitForAction(opponent, defenderStart)
+		require.NoError(t, err)
+		assert.Equal(t, 2, action.MinSelections)
+		assert.Equal(t, 2, action.MaxSelections)
+
+		require.NoError(t, scn.SubmitAction(opponent, shields[0].ID, shields[1].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		assert.Equal(t, match.HAND, shields[0].Zone)
+		assert.Equal(t, match.HAND, shields[1].Zone)
+	})
+
+	t.Run("Meloppe leaving play beforehand restores the attacker as chooser", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		meloppe := putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		attacker := putCardInBattlezone(t, scn, player.Player, meloppeVanillaAttackerUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		_, err := opponent.Player.MoveCard(meloppe.ID, match.BATTLEZONE, match.GRAVEYARD, meloppeSetupSrc)
+		require.NoError(t, err)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.NotEmpty(t, shields)
+
+		attackerStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+
+		require.NoError(t, scn.ActionAttackPlayerAsync(player, attacker.ID))
+
+		action, err := scn.WaitForAction(player, attackerStart)
+		require.NoError(t, err, "expected the attacker to be prompted again once Meloppe left play")
+		assert.True(t, action.Cancellable)
+
+		require.NoError(t, scn.SubmitAction(player, shields[0].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		assert.Equal(t, match.HAND, shields[0].Zone)
+	})
+}

--- a/sim/tests/cards/meloppe_test.go
+++ b/sim/tests/cards/meloppe_test.go
@@ -23,6 +23,63 @@ const (
 	// meloppeDoubleBreakerUID is Astrocomet Dragon: double breaker with no
 	// other effect, used to confirm the shield count survives the swap.
 	meloppeDoubleBreakerUID = "91db2302-6794-4aa4-b17b-6637d356e9ac"
+
+	// meloppeAquaMasterUID is Aqua Master: "Whenever this creature attacks a
+	// player and isn't blocked, choose one of your opponent's shields and turn
+	// it face up." Used to confirm Meloppe also reverses the chooser for a
+	// shield-choosing effect that isn't the default shield-break selection.
+	meloppeAquaMasterUID = "2b33507e-0154-43f7-a190-e84178ea81c9"
+
+	// meloppeCosmicDartsUID is Cosmic Darts: "Your opponent chooses one of
+	// your shields..." Unlike every other case here, the printed default
+	// chooser is the caster's *opponent*, choosing among the *caster's* own
+	// shields. Used to confirm Meloppe's other clause: when the caster
+	// controls Meloppe, the caster chooses instead of letting the opponent
+	// pick.
+	meloppeCosmicDartsUID = "0fe53ab5-bef9-4bbd-bb05-c94ccb9b1342"
+
+	// meloppeInvincibleCataclysmUID is Invincible Cataclysm: "Choose up to 3
+	// of your opponent's shields and put them into his graveyard." A
+	// cross-player choice made outside any attack, to confirm the general
+	// ChooseShieldEvent mechanism (not just SelectShields) is reversed.
+	meloppeInvincibleCataclysmUID = "d8aee1e9-0799-4acf-af2a-3a8fd1b4eb8e"
+
+	// meloppeReconOperationUID is Recon Operation: "Look at up to 3 of your
+	// opponent's shields." A non-mutating "look" effect, to confirm the fix
+	// covers effects that never move or break anything.
+	meloppeReconOperationUID = "aa1cca8a-3140-4180-9c9f-3f126dd16a68"
+
+	// meloppeGajirabuteUID is Gajirabute, Vile Centurion: "When it comes into
+	// play, choose one of your opponent's shields and put it into his
+	// graveyard." Exercises fx.PutOpShieldIntoGraveyard, a shared helper fixed
+	// once for every card that calls it.
+	meloppeGajirabuteUID = "e2552e90-61bf-46ec-80a6-28666bfccd1c"
+
+	// meloppePointaUID is Pointa, the Aqua Shadow: "When it comes into play,
+	// look at 1 of your opponent's shields. Then your opponent discards a
+	// card at random from their hand." Exercises fx.ShowXShields, another
+	// shared helper.
+	meloppePointaUID = "bc128af9-0fc2-4a1b-b10e-2f695f05c24e"
+
+	// meloppeStingerBallUID is Stinger Ball: "Whenever this creature attacks,
+	// you may look at 1 of your opponent's shields." Exercises
+	// fx.WheneverThisAttacksMayLookAtOpShield, which fires on AttackConfirmed
+	// rather than SelectShields, to confirm the fix isn't tied to the
+	// shield-break flow specifically.
+	meloppeStingerBallUID = "fb3a5abd-c16a-4365-98c0-79753fdcd91d"
+
+	// meloppeAdomisUID is Adomis, the Oracle: "$tap Choose a shield and look
+	// at it." Names no owner, so the offer spans both shield zones in one
+	// blind pick. Used to confirm that when the picker's blind pick lands on
+	// the opponent's zone, the opponent chooses which of their own shields is
+	// affected instead.
+	meloppeAdomisUID = "c30f60d5-d97c-457e-b438-e4a606136171"
+
+	// meloppeUlarusUID is Ularus, Punishment Elemental: "for each creature you
+	// have in the battle zone, you may choose a shield and turn it face up."
+	// Same owner-agnostic pool as Adomis, but multi-select instead of a single
+	// pick.
+	meloppeUlarusUID = "05c5496d-e5fa-4691-8542-2d6c6919f402"
 )
 
 func TestMeloppe(t *testing.T) {
@@ -60,6 +117,7 @@ func TestMeloppe(t *testing.T) {
 		assert.Equal(t, 1, action.MinSelections)
 		assert.Equal(t, 1, action.MaxSelections)
 		assert.Len(t, action.Cards, len(shields))
+		assert.Contains(t, action.Text, "Meloppe", "the prompt should explain why the defender is the one choosing")
 
 		// The attacker never received a shield-selection prompt of their own,
 		// only the "waiting for your opponent" notice.
@@ -92,6 +150,7 @@ func TestMeloppe(t *testing.T) {
 		action, err := scn.WaitForAction(opponent, defenderStart)
 		require.NoError(t, err, "expected the defender to be prompted even though they don't control Meloppe")
 		assert.False(t, action.Cancellable)
+		assert.Contains(t, action.Text, "Meloppe")
 
 		chosen := shields[0]
 		require.NoError(t, scn.SubmitAction(opponent, chosen.ID))
@@ -121,12 +180,79 @@ func TestMeloppe(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 2, action.MinSelections)
 		assert.Equal(t, 2, action.MaxSelections)
+		assert.Contains(t, action.Text, "Meloppe")
 
 		require.NoError(t, scn.SubmitAction(opponent, shields[0].ID, shields[1].ID))
 		require.NoError(t, scn.WaitForEventLoop())
 
 		assert.Equal(t, match.HAND, shields[0].Zone)
 		assert.Equal(t, match.HAND, shields[1].Zone)
+	})
+
+	t.Run("Aqua Master's face-up choice goes to the defender instead of the attacker", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		aquaMaster := putCardInBattlezone(t, scn, player.Player, meloppeAquaMasterUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(shields), 2)
+
+		attackerStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		defenderStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		require.NoError(t, scn.ActionAttackPlayerAsync(player, aquaMaster.ID))
+
+		// Aqua Master's ShieldsSelectionEffect condition makes it confirm the
+		// attack up front, before any shield is involved.
+		confirm, err := scn.WaitForAction(player, attackerStart)
+		require.NoError(t, err)
+		assert.Equal(t, "question", confirm.ActionType)
+		require.NoError(t, scn.SubmitAction(player))
+
+		faceUpPrompt, err := scn.WaitForAction(opponent, defenderStart)
+		require.NoError(t, err, "expected the defender, not the attacker, to choose which shield gets turned face up")
+		assert.Contains(t, faceUpPrompt.Text, "turn it face up")
+		assert.Contains(t, faceUpPrompt.Text, "Meloppe")
+		assert.False(t, faceUpPrompt.Cancellable)
+		assert.Equal(t, 1, faceUpPrompt.MinSelections)
+		assert.Equal(t, 1, faceUpPrompt.MaxSelections)
+
+		// The attacker never received a prompt of their own for this choice.
+		attackerHeaders, err := scn.MessageHeaders(player, attackerStart)
+		require.NoError(t, err)
+		assert.Equal(t, 1, countHeaders(attackerHeaders, "action"), "the attacker should only have seen their own attack confirmation")
+
+		chosenToFlip := shields[0]
+		midStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+		require.NoError(t, scn.SubmitAction(opponent, chosenToFlip.ID))
+
+		breakPrompt, err := scn.WaitForAction(opponent, midStart)
+		require.NoError(t, err, "expected the defender to also be asked which shield to break")
+		assert.Contains(t, breakPrompt.Text, "Select 1 shield")
+		assert.Contains(t, breakPrompt.Text, "Meloppe")
+
+		// Flipping it face up makes chosenToFlip visible from now on, but the
+		// attacker still wasn't there for the defender's pick, so the chat
+		// message is what ties "shield #1" back to what just happened. Waiting
+		// for breakPrompt above proves this already arrived.
+		chats, err := scn.ChatMessages(opponent, midStart)
+		require.NoError(t, err)
+		require.NotEmpty(t, chats)
+		assert.Contains(t, chats[0], "shield #1")
+		assert.Contains(t, chats[0], chosenToFlip.Name)
+
+		chosenToBreak := shields[1]
+		require.NoError(t, scn.SubmitAction(opponent, chosenToBreak.ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		assert.True(t, chosenToFlip.ShieldFaceUp, "the shield the defender chose should be the one turned face up")
+		assert.Equal(t, match.HAND, chosenToBreak.Zone)
 	})
 
 	t.Run("Meloppe leaving play beforehand restores the attacker as chooser", func(t *testing.T) {
@@ -151,10 +277,366 @@ func TestMeloppe(t *testing.T) {
 		action, err := scn.WaitForAction(player, attackerStart)
 		require.NoError(t, err, "expected the attacker to be prompted again once Meloppe left play")
 		assert.True(t, action.Cancellable)
+		assert.NotContains(t, action.Text, "Meloppe", "there is nothing to explain once Meloppe is gone")
 
 		require.NoError(t, scn.SubmitAction(player, shields[0].ID))
 		require.NoError(t, scn.WaitForEventLoop())
 
 		assert.Equal(t, match.HAND, shields[0].Zone)
+	})
+
+	t.Run("Cosmic Darts: the caster chooses their own shield instead of the opponent", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		// Meloppe belongs to the caster here, exercising the clause where an
+		// opponent's effect would choose one of Meloppe's controller's own
+		// shields.
+		putCardInBattlezone(t, scn, player.Player, meloppeUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := player.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.NotEmpty(t, shields)
+
+		playerStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		opponentStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		castSpell(t, scn, player, meloppeCosmicDartsUID)
+
+		// The opponent is the printed default chooser and never got a prompt
+		// of their own.
+		opponentHeaders, err := scn.MessageHeaders(opponent, opponentStart)
+		require.NoError(t, err)
+		assert.NotContains(t, opponentHeaders, "action")
+
+		prompt, err := scn.LatestAction(player, playerStart)
+		require.NoError(t, err, "expected the caster, not the opponent, to choose which of their own shields is revealed")
+		assert.False(t, prompt.Cancellable)
+		assert.Equal(t, 1, prompt.MinSelections)
+		assert.Equal(t, 1, prompt.MaxSelections)
+		assert.Len(t, prompt.Cards, len(shields))
+		assert.Contains(t, prompt.Text, "Meloppe")
+
+		require.NoError(t, scn.SubmitAction(player, shields[0].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		// A non-spell shield is only shown, then put back; the choice having
+		// gone to the right player is what this test is checking.
+		assert.Equal(t, match.SHIELDZONE, shields[0].Zone)
+	})
+
+	t.Run("Invincible Cataclysm: the defender chooses which of their own shields are destroyed", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(shields), 3)
+
+		defenderStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		castSpell(t, scn, player, meloppeInvincibleCataclysmUID)
+
+		prompt, err := scn.WaitForAction(opponent, defenderStart)
+		require.NoError(t, err, "expected the defender, not the caster, to choose which of their own shields are destroyed")
+		assert.True(t, prompt.Cancellable)
+		assert.Equal(t, 1, prompt.MinSelections)
+		assert.Equal(t, 3, prompt.MaxSelections)
+		assert.Contains(t, prompt.Text, "Meloppe")
+
+		require.NoError(t, scn.SubmitAction(opponent, shields[0].ID, shields[1].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		assert.Equal(t, match.GRAVEYARD, shields[0].Zone)
+		assert.Equal(t, match.GRAVEYARD, shields[1].Zone)
+	})
+
+	t.Run("Recon Operation: the defender chooses which of their own shields are shown", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(shields), 3)
+
+		defenderStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		castSpell(t, scn, player, meloppeReconOperationUID)
+
+		prompt, err := scn.WaitForAction(opponent, defenderStart)
+		require.NoError(t, err, "expected the defender to choose which of their own shields are looked at")
+		assert.True(t, prompt.Cancellable)
+		assert.Contains(t, prompt.Text, "Meloppe")
+
+		revealStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		require.NoError(t, scn.SubmitAction(opponent, shields[0].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		// Recon Operation only looks; nothing moves.
+		assert.Equal(t, match.SHIELDZONE, shields[0].Zone)
+
+		// The caster never saw the defender choose, so the pop-up and chat
+		// message are the only way to know which shield #1 it was.
+		popups, err := scn.ShowCardsMessages(player, revealStart)
+		require.NoError(t, err)
+		require.Len(t, popups, 1)
+		assert.Contains(t, popups[0], "shield #1")
+
+		chats, err := scn.ChatMessages(player, revealStart)
+		require.NoError(t, err)
+		require.NotEmpty(t, chats)
+		assert.Contains(t, chats[0], "shield #1")
+	})
+
+	t.Run("Gajirabute: the defender chooses which of their own shields goes to the graveyard", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.NotEmpty(t, shields)
+
+		defenderStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		summonWithOwnMana(t, scn, player, meloppeGajirabuteUID)
+
+		prompt, err := scn.WaitForAction(opponent, defenderStart)
+		require.NoError(t, err, "expected the defender, not the summoner, to choose which of their own shields is discarded")
+		assert.False(t, prompt.Cancellable)
+		assert.Contains(t, prompt.Text, "Meloppe")
+
+		require.NoError(t, scn.SubmitAction(opponent, shields[0].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		assert.Equal(t, match.GRAVEYARD, shields[0].Zone)
+	})
+
+	t.Run("Pointa: the defender chooses which of their own shields is shown", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.NotEmpty(t, shields)
+
+		defenderStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		summonWithOwnMana(t, scn, player, meloppePointaUID)
+
+		prompt, err := scn.WaitForAction(opponent, defenderStart)
+		require.NoError(t, err, "expected the defender to choose which of their own shields is looked at")
+		assert.False(t, prompt.Cancellable)
+		assert.Contains(t, prompt.Text, "Meloppe")
+
+		revealStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		require.NoError(t, scn.SubmitAction(opponent, shields[0].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		// Pointa only looks; nothing moves.
+		assert.Equal(t, match.SHIELDZONE, shields[0].Zone)
+
+		// The summoner never saw the defender choose, so the pop-up is the only
+		// way to know which shield #1 it was.
+		popups, err := scn.ShowCardsMessages(player, revealStart)
+		require.NoError(t, err)
+		require.Len(t, popups, 1)
+		assert.Contains(t, popups[0], "shield #1")
+
+		chats, err := scn.ChatMessages(player, revealStart)
+		require.NoError(t, err)
+		require.NotEmpty(t, chats)
+		assert.Contains(t, chats[0], "shield #1")
+	})
+
+	t.Run("Stinger Ball: the defender chooses which of their own shields is looked at on attack", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		attacker := putCardInBattlezone(t, scn, player.Player, meloppeStingerBallUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.NotEmpty(t, shields)
+
+		attackerStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		defenderStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		require.NoError(t, scn.ActionAttackPlayerAsync(player, attacker.ID))
+
+		// Stinger Ball also carries ShieldsSelectionEffect, so the attack
+		// confirms up front before its "may look" ability fires.
+		confirm, err := scn.WaitForAction(player, attackerStart)
+		require.NoError(t, err)
+		assert.Equal(t, "question", confirm.ActionType)
+		require.NoError(t, scn.SubmitAction(player))
+
+		lookPrompt, err := scn.WaitForAction(opponent, defenderStart)
+		require.NoError(t, err, "expected the defender, not the attacker, to choose which of their own shields is looked at")
+		assert.True(t, lookPrompt.Cancellable)
+		assert.Contains(t, lookPrompt.Text, "Meloppe")
+
+		midStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+		playerMidStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		require.NoError(t, scn.SubmitAction(opponent, shields[0].ID))
+
+		// The attacker is shown the revealed shield through a non-dismissible
+		// prompt of their own; it has to be closed before the attack sequence
+		// can continue to the shield-break selection.
+		require.NoError(t, scn.WaitForMessage(player, playerMidStart, "show_cards_non_dismissible"))
+
+		// The attacker never saw the defender choose, so the pop-up and chat
+		// message are the only way to know which shield #1 it was.
+		popups, err := scn.ShowCardsMessages(player, playerMidStart)
+		require.NoError(t, err)
+		require.Len(t, popups, 1)
+		assert.Contains(t, popups[0], "shield #1")
+
+		chats, err := scn.ChatMessages(player, playerMidStart)
+		require.NoError(t, err)
+		require.NotEmpty(t, chats)
+		assert.Contains(t, chats[0], "shield #1")
+
+		require.NoError(t, scn.CancelAction(player))
+
+		// The mandatory shield-break selection follows right after.
+		breakPrompt, err := scn.WaitForAction(opponent, midStart)
+		require.NoError(t, err)
+		assert.Contains(t, breakPrompt.Text, "Select 1 shield")
+		assert.Contains(t, breakPrompt.Text, "Meloppe")
+
+		require.NoError(t, scn.SubmitAction(opponent, shields[1].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		// Stinger Ball's look effect only shows the shield; the break is what moves it.
+		assert.Equal(t, match.SHIELDZONE, shields[0].Zone)
+		assert.Equal(t, match.HAND, shields[1].Zone)
+	})
+
+	t.Run("Adomis: a blind pick landing on the opponent's zone lets them choose which shield instead", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+		adomis := putCardInBattlezone(t, scn, player.Player, meloppeAdomisUID, meloppeSetupSrc)
+		passTurnToSelf(t, scn, player, opponent)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.NotEmpty(t, shields)
+
+		playerStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		opponentStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		require.NoError(t, scn.ActionUseTapAbility(player, adomis.ID))
+		_, err = scn.WaitForMultipartAction(player, playerStart)
+		require.NoError(t, err)
+
+		// The picker's blind pick names a specific shield of the opponent's,
+		// even though the client only sees it face down.
+		require.NoError(t, scn.SubmitAction(player, shields[0].ID))
+
+		prompt, err := scn.WaitForAction(opponent, opponentStart)
+		require.NoError(t, err, "expected the defender, not the picker, to choose which of their own shields is looked at")
+		assert.False(t, prompt.Cancellable, "the picker already committed to affecting one of the defender's shields")
+		assert.Equal(t, 1, prompt.MinSelections)
+		assert.Equal(t, 1, prompt.MaxSelections)
+		assert.Contains(t, prompt.Text, "Meloppe")
+
+		// The defender's own choice (shields[1], their shield #2) is what
+		// actually gets revealed, not the picker's earlier blind pick.
+		revealStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		require.NoError(t, scn.SubmitAction(opponent, shields[1].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		// Adomis only looks; nothing moves either way.
+		assert.Equal(t, match.SHIELDZONE, shields[0].Zone)
+		assert.Equal(t, match.SHIELDZONE, shields[1].Zone)
+
+		// The picker (player) never saw the defender choose, so the pop-up and
+		// chat message are the only way to know which shield #2 turned out to
+		// be, and whose it was.
+		popups, err := scn.ShowCardsMessages(player, revealStart)
+		require.NoError(t, err)
+		require.Len(t, popups, 1)
+		assert.Contains(t, popups[0], "shield #2")
+		assert.Contains(t, popups[0], shields[1].Name)
+
+		chats, err := scn.ChatMessages(player, revealStart)
+		require.NoError(t, err)
+		require.Len(t, chats, 1)
+		assert.Contains(t, chats[0], "shield #2")
+		assert.Contains(t, chats[0], shields[1].Name)
+		assert.Contains(t, chats[0], opponent.Player.Username())
+		assert.Contains(t, chats[0], player.Player.Username())
+	})
+
+	t.Run("Ularus: a blind pick landing on the opponent's zone lets them choose which shield is turned face up", func(t *testing.T) {
+		scn, player, opponent := setupDuel(t)
+
+		putCardInBattlezone(t, scn, opponent.Player, meloppeUID, meloppeSetupSrc)
+
+		shields, err := opponent.Player.Container(match.SHIELDZONE)
+		require.NoError(t, err)
+		require.NotEmpty(t, shields)
+
+		playerStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		opponentStart, err := scn.MessageCount(opponent)
+		require.NoError(t, err)
+
+		// Summoned alone, so its allowance (one shield per own creature in the
+		// battle zone, itself included) is exactly 1.
+		summonWithOwnMana(t, scn, player, meloppeUlarusUID)
+		_, err = scn.WaitForMultipartAction(player, playerStart)
+		require.NoError(t, err)
+
+		require.NoError(t, scn.SubmitAction(player, shields[0].ID))
+
+		prompt, err := scn.WaitForAction(opponent, opponentStart)
+		require.NoError(t, err, "expected the defender, not the summoner, to choose which of their own shields is turned face up")
+		assert.False(t, prompt.Cancellable)
+		assert.Equal(t, 1, prompt.MinSelections)
+		assert.Equal(t, 1, prompt.MaxSelections)
+		assert.Contains(t, prompt.Text, "Meloppe")
+
+		revealStart, err := scn.MessageCount(player)
+		require.NoError(t, err)
+		require.NoError(t, scn.SubmitAction(opponent, shields[1].ID))
+		require.NoError(t, scn.WaitForEventLoop())
+
+		assert.False(t, shields[0].ShieldFaceUp, "the picker's blind pick should have been discarded, not turned face up")
+		assert.True(t, shields[1].ShieldFaceUp, "the defender's own choice should be the one turned face up")
+
+		// Flipping it face up makes shields[1] visible from now on, but the
+		// summoner still wasn't there for the defender's pick, so the chat
+		// message is what ties "shield #2" back to what just happened.
+		chats, err := scn.ChatMessages(player, revealStart)
+		require.NoError(t, err)
+		require.NotEmpty(t, chats)
+		assert.Contains(t, chats[0], "shield #2")
+		assert.Contains(t, chats[0], shields[1].Name)
 	})
 }

--- a/sim/tests/scenario/scenario.go
+++ b/sim/tests/scenario/scenario.go
@@ -728,6 +728,34 @@ func (s *TestScenario) ChatMessages(player *match.PlayerReference, since int) ([
 	return messages, nil
 }
 
+// ShowCardsMessages returns the "message" text of every show_cards or
+// show_cards_non_dismissible pop-up sent to player since the given count, in
+// the order they arrived.
+func (s *TestScenario) ShowCardsMessages(player *match.PlayerReference, since int) ([]string, error) {
+	conn, err := s.connectionFor(player)
+	if err != nil {
+		return nil, err
+	}
+
+	messages := make([]string, 0)
+	for _, raw := range conn.JSONMessagesSince(since) {
+		var header server.Message
+		if err := json.Unmarshal([]byte(raw), &header); err != nil {
+			continue
+		}
+		if header.Header != "show_cards" && header.Header != "show_cards_non_dismissible" {
+			continue
+		}
+
+		message := &server.ShowCardsMessage{}
+		if err := json.Unmarshal([]byte(raw), message); err == nil {
+			messages = append(messages, message.Message)
+		}
+	}
+
+	return messages, nil
+}
+
 // MessageCount returns the number of JSON messages the server has sent to the player so far.
 // Capture this value BEFORE an action so that WaitForMessage can find the response.
 func (s *TestScenario) MessageCount(player *match.PlayerReference) (int, error) {

--- a/sim/tests/scenario/scenario.go
+++ b/sim/tests/scenario/scenario.go
@@ -470,6 +470,25 @@ func (s *TestScenario) ActionAttackPlayer(player *match.PlayerReference, attacke
 	return s.waitForAttackPrompt(player, messageCount)
 }
 
+// ActionAttackPlayerAsync declares a player attack but, unlike ActionAttackPlayer,
+// does not assume the attacker is who gets prompted for the resulting shield
+// selection. Use it when a persistent effect (e.g. Meloppe) may redirect that
+// prompt to the defender instead; follow up with WaitForAction on whichever
+// player is expected to answer it.
+func (s *TestScenario) ActionAttackPlayerAsync(player *match.PlayerReference, attackerID string) error {
+	if _, err := player.Player.GetCard(attackerID, match.BATTLEZONE); err != nil {
+		return err
+	}
+
+	return s.send(player, struct {
+		Header string `json:"header"`
+		ID     string `json:"virtualId"`
+	}{
+		Header: "attack_player",
+		ID:     attackerID,
+	})
+}
+
 // ActionAttackCreaturePrompt attacks with a creature and returns the target
 // selection prompt without answering it, for tests that need to cancel it. The
 // caller must always answer that prompt through SubmitAction or CancelAction so


### PR DESCRIPTION
## 📝 Summary

New card: Meloppe + lots of helper methods needed

## 🎴 New Cards Added

- Meloppe

## 🐞 Bugs Fixed

-

## 🔧 Other Changes

- Fix Meloppe not reversing shield choices outside the default break flow
- Meloppe's controller-swap only intercepted match.SelectShields, the event fired by the default shield-break selection. Any other "choose one of a player's shields" effect (Aqua Master, look-at-a-shield abilities, spells that discard/destroy a shield, etc.) still let its normal chooser pick, even when that chooser was choosing among the shields Meloppe protects.
- Add match.ChooseShieldEvent plus fx.ResolveShieldChooser, fired by any  cross-player shield choice outside the attack/break flow. Meloppe's  persistent effect now redirects both this and SelectShields with the  same rule: the shield's own owner always picks, regardless of which  side controls Meloppe.
- Add fx.ResolveShieldChoices for the two cards that offer one blind pick  across *both* players' shield zones at once (Ularus, Adomis). The  original pick is discarded and replaced with a fresh, mandatory pick by  the shield's owner whenever it lands on a zone Meloppe protects, since  nothing about the blind pick was ever revealed to begin with.
- Wire the redirect into every affected call site found by an exhaustive audit of every "choose a shield" mechanism in the codebase: Aqua  Master, fx.BreakXOpShields/DestroyOpShield, fx.PutOpShieldIntoGraveyard,  fx.ShowXShields, x.WheneverThisAttacksMayLookAtOpShield, Recon  Operation, Invincible Cataclysm, Cosmic Darts (the one card where the  printed default chooser is the *opponent*, exercising Meloppe's other clause), Ularus, and Adomis.
- Append "(Meloppe's effect: you choose instead of your oppone  the redirected prompt's text so a player unfamiliar with Meloppe isn't  left confused about why they're suddenly the one being asked
- Add fx.ShieldNumber/fx.DescribeShield and use them in every reveal  pop-up and chat message a redirected pick produces, so the player receives the reveal (and never saw the pick happen) can tell which  shield, by number and name, it was. Applied the same fix to Darts' non-Meloppe default behavior too, since the opponent is its printed default chooser and hits the identical ambiguity.
- Fix an ordering bug found while wiring in the chat message for   WheneverThisAttacksMayLookAtOpShield: it was reported after
  ShowCardsNonDismissible, which blocks until the attacker dismisses the  popup, so the defender who picked would see no confirmation

Adds ~30 new test cases across meloppe_test.go and cosmic_dart
plus a ShowCardsMessages scenario helper to assert on pop-up content.
Verified every new test fails with its corresponding fix rever

## ✅ Checklist

Please confirm the following before submitting your PR:

- [x] I have read [CONTRIBUTING.md](https://github.com/sindreslungaard/duel-masters/blob/master/CONTRIBUTING.md)
- [x] The changes has been tested locally
- [x] Tests are written that covers the changes made and any bugs fixed (`./sim/tests`)

## 📸 Screenshots (if applicable)

If there are any visual changes to the frontend, please include some screenshots or screen recordings of it
